### PR TITLE
refactor: consolidate 47 tools into 8 unified action-based tools

### DIFF
--- a/cmd/lib.go
+++ b/cmd/lib.go
@@ -8,95 +8,25 @@ package cmd
 
 import (
 	"github.com/raohwork/forgejo-mcp/tools"
-	"github.com/raohwork/forgejo-mcp/tools/action"
-	"github.com/raohwork/forgejo-mcp/tools/issue"
-	"github.com/raohwork/forgejo-mcp/tools/label"
-	"github.com/raohwork/forgejo-mcp/tools/milestone"
-	"github.com/raohwork/forgejo-mcp/tools/pullreq"
-	"github.com/raohwork/forgejo-mcp/tools/release"
-	"github.com/raohwork/forgejo-mcp/tools/repo"
-	"github.com/raohwork/forgejo-mcp/tools/wiki"
+	"github.com/raohwork/forgejo-mcp/tools/unified"
 	"github.com/raohwork/forgejo-mcp/types"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func registerCommands(s *mcp.Server, cl *tools.Client) {
-	// Issue tools
-	tools.Register(s, &issue.ListRepoIssuesImpl{Client: cl})
-	tools.Register(s, &issue.GetIssueImpl{Client: cl})
-	tools.Register(s, &issue.CreateIssueImpl{Client: cl})
-	tools.Register(s, &issue.EditIssueImpl{Client: cl})
-
-	// Issue label tools
-	tools.Register(s, &issue.AddIssueLabelsImpl{Client: cl})
-	tools.Register(s, &issue.RemoveIssueLabelImpl{Client: cl})
-	tools.Register(s, &issue.ReplaceIssueLabelsImpl{Client: cl})
-
-	// Issue comment tools
-	tools.Register(s, &issue.ListIssueCommentsImpl{Client: cl})
-	tools.Register(s, &issue.CreateIssueCommentImpl{Client: cl})
-	tools.Register(s, &issue.EditIssueCommentImpl{Client: cl})
-	tools.Register(s, &issue.DeleteIssueCommentImpl{Client: cl})
-
-	// Issue attachment tools
-	tools.Register(s, &issue.ListIssueAttachmentsImpl{Client: cl})
-	tools.Register(s, &issue.DeleteIssueAttachmentImpl{Client: cl})
-	tools.Register(s, &issue.EditIssueAttachmentImpl{Client: cl})
-
-	// Issue dependency tools
-	tools.Register(s, &issue.ListIssueDependenciesImpl{Client: cl})
-	tools.Register(s, &issue.AddIssueDependencyImpl{Client: cl})
-	tools.Register(s, &issue.RemoveIssueDependencyImpl{Client: cl})
-
-	// Issue blocking tools
-	tools.Register(s, &issue.ListIssueBlockingImpl{Client: cl})
-	tools.Register(s, &issue.AddIssueBlockingImpl{Client: cl})
-	tools.Register(s, &issue.RemoveIssueBlockingImpl{Client: cl})
-
-	// Label tools
-	tools.Register(s, &label.ListRepoLabelsImpl{Client: cl})
-	tools.Register(s, &label.CreateLabelImpl{Client: cl})
-	tools.Register(s, &label.EditLabelImpl{Client: cl})
-	tools.Register(s, &label.DeleteLabelImpl{Client: cl})
-
-	// Milestone tools
-	tools.Register(s, &milestone.ListRepoMilestonesImpl{Client: cl})
-	tools.Register(s, &milestone.CreateMilestoneImpl{Client: cl})
-	tools.Register(s, &milestone.EditMilestoneImpl{Client: cl})
-	tools.Register(s, &milestone.DeleteMilestoneImpl{Client: cl})
-
-	// Release tools
-	tools.Register(s, &release.ListReleasesImpl{Client: cl})
-	tools.Register(s, &release.CreateReleaseImpl{Client: cl})
-	tools.Register(s, &release.EditReleaseImpl{Client: cl})
-	tools.Register(s, &release.DeleteReleaseImpl{Client: cl})
-
-	// Release attachment tools
-	tools.Register(s, &release.ListReleaseAttachmentsImpl{Client: cl})
-	tools.Register(s, &release.EditReleaseAttachmentImpl{Client: cl})
-	tools.Register(s, &release.DeleteReleaseAttachmentImpl{Client: cl})
-
-	// Pull request tools
-	tools.Register(s, &pullreq.ListPullRequestsImpl{Client: cl})
-	tools.Register(s, &pullreq.GetPullRequestImpl{Client: cl})
-	tools.Register(s, &pullreq.CreatePullRequestImpl{Client: cl})
-
-	// Repository tools
-	tools.Register(s, &repo.SearchRepositoriesImpl{Client: cl})
-	tools.Register(s, &repo.ListMyRepositoriesImpl{Client: cl})
-	tools.Register(s, &repo.ListOrgRepositoriesImpl{Client: cl})
-	tools.Register(s, &repo.GetRepositoryImpl{Client: cl})
-
-	// Wiki tools
-	tools.Register(s, &wiki.GetWikiPageImpl{Client: cl})
-	tools.Register(s, &wiki.CreateWikiPageImpl{Client: cl})
-	tools.Register(s, &wiki.EditWikiPageImpl{Client: cl})
-	tools.Register(s, &wiki.DeleteWikiPageImpl{Client: cl})
-	tools.Register(s, &wiki.ListWikiPagesImpl{Client: cl})
-
-	// Action tools
-	tools.Register(s, &action.ListActionTasksImpl{Client: cl})
+	// Use unified tools (8 tools instead of 47)
+	// This reduces token consumption by ~80% while maintaining full functionality.
+	// The unified tools use action-based organization:
+	// - gitea_manual: On-demand documentation lookup
+	// - create_gitea: Create resources (issue, label, milestone, release, wiki_page, pull_request, issue_comment)
+	// - get_gitea: Get single resources (issue, wiki_page, pull_request, repository)
+	// - list_gitea: List resources (issues, labels, milestones, releases, wiki_pages, pull_requests, repositories, etc.)
+	// - edit_gitea: Edit resources (issue, label, milestone, release, wiki_page, etc.)
+	// - delete_gitea: Delete resources (label, milestone, release, wiki_page, issue_comment, etc.)
+	// - link_gitea: Create relationships (issue↔label, issue dependencies, issue blocking)
+	// - unlink_gitea: Remove relationships
+	unified.RegisterAll(s, cl)
 }
 
 func createServer(cl *tools.Client) *mcp.Server {

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,6 @@ github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIx
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/jsonschema-go v0.2.0 h1:Uh19091iHC56//WOsAd1oRg6yy1P9BpSvpjOL6RcjLQ=
-github.com/google/jsonschema-go v0.2.0/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/jsonschema-go v0.2.1-0.20250825175020-748c325cec76 h1:mBlBwtDebdDYr+zdop8N62a44g+Nbv7o2KjWyS1deR4=
 github.com/google/jsonschema-go v0.2.1-0.20250825175020-748c325cec76/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
@@ -30,8 +28,6 @@ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/modelcontextprotocol/go-sdk v0.2.1-0.20250812214950-6e03217c831b h1:UY+mamH9fcvW4D7X2DcNnTUNSFagNNr85evEF1xAdqs=
-github.com/modelcontextprotocol/go-sdk v0.2.1-0.20250812214950-6e03217c831b/go.mod h1:71VUZVa8LL6WARvSgLJ7DMpDWSeomT4uBv8g97mGBvo=
 github.com/modelcontextprotocol/go-sdk v0.4.0 h1:RJ6kFlneHqzTKPzlQqiunrz9nbudSZcYLmLHLsokfoU=
 github.com/modelcontextprotocol/go-sdk v0.4.0/go.mod h1:whv0wHnsTphwq7CTiKYHkLtwLC06WMoY2KpO+RB9yXQ=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=

--- a/tools/unified/create.go
+++ b/tools/unified/create.go
@@ -1,0 +1,409 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright © 2025 Ronmi Ren <ronmi.ren@gmail.com>
+
+package unified
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	"codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v2"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/raohwork/forgejo-mcp/tools"
+	"github.com/raohwork/forgejo-mcp/types"
+)
+
+// CreateParams defines the parameters for the create_gitea tool.
+// Uses a generic map to handle varying parameters per resource type.
+type CreateParams struct {
+	Resource string         `json:"resource"`
+	Params   map[string]any `json:"params"`
+}
+
+// CreateImpl implements the create_gitea tool.
+type CreateImpl struct {
+	Client *tools.Client
+}
+
+// Definition describes the create_gitea tool with minimal schema.
+func (CreateImpl) Definition() *mcp.Tool {
+	return &mcp.Tool{
+		Name:  "create_gitea",
+		Title: "Create Gitea Resource",
+		Description: `Create a resource in Forgejo/Gitea.
+Resources: issue, issue_comment, label, milestone, release, wiki_page, pull_request.
+Use gitea_manual(action="create") for details.`,
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:    false,
+			DestructiveHint: tools.BoolPtr(false),
+			IdempotentHint:  false,
+		},
+		InputSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"resource": {
+					Type:        "string",
+					Description: "Resource type to create",
+					Enum:        []any{"issue", "issue_comment", "label", "milestone", "release", "wiki_page", "pull_request"},
+				},
+				"owner": {
+					Type:        "string",
+					Description: "Repository owner",
+				},
+				"repo": {
+					Type:        "string",
+					Description: "Repository name",
+				},
+			},
+			Required:             []string{"resource", "owner", "repo"},
+			AdditionalProperties: &jsonschema.Schema{},
+		},
+	}
+}
+
+// Handler dispatches to the appropriate creation logic based on resource type.
+func (impl CreateImpl) Handler() mcp.ToolHandlerFor[map[string]any, any] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+		resource, _ := args["resource"].(string)
+		if resource == "" {
+			resources := ListResourcesForAction(ActionCreate)
+			return nil, nil, fmt.Errorf("resource is required. Valid resources: %v", resources)
+		}
+
+		// Validate resource type
+		if _, ok := LookupManual(ActionCreate, resource); !ok {
+			resources := ListResourcesForAction(ActionCreate)
+			return nil, nil, fmt.Errorf("unknown resource '%s'. Valid resources: %v", resource, resources)
+		}
+
+		switch resource {
+		case "issue":
+			return impl.createIssue(args)
+		case "issue_comment":
+			return impl.createIssueComment(args)
+		case "label":
+			return impl.createLabel(args)
+		case "milestone":
+			return impl.createMilestone(args)
+		case "release":
+			return impl.createRelease(args)
+		case "wiki_page":
+			return impl.createWikiPage(args)
+		case "pull_request":
+			return impl.createPullRequest(args)
+		default:
+			return nil, nil, fmt.Errorf(FormatValidationError(ActionCreate, resource, "not implemented"))
+		}
+	}
+}
+
+func (impl CreateImpl) createIssue(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionCreate, "issue", err.Error()))
+	}
+
+	title, _ := args["title"].(string)
+	if title == "" {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionCreate, "issue", "title is required"))
+	}
+
+	body, _ := args["body"].(string)
+	if body == "" {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionCreate, "issue", "body is required"))
+	}
+
+	opt := forgejo.CreateIssueOption{
+		Title: title,
+		Body:  body,
+	}
+
+	if assignees, ok := args["assignees"].([]any); ok {
+		opt.Assignees = toStringSlice(assignees)
+	}
+
+	if milestone, ok := args["milestone"].(float64); ok && milestone > 0 {
+		opt.Milestone = int64(milestone)
+	}
+
+	if labels, ok := args["labels"].([]any); ok {
+		opt.Labels = toInt64Slice(labels)
+	}
+
+	if dueDateStr, ok := args["due_date"].(string); ok && dueDateStr != "" {
+		dueDate, err := time.Parse(time.RFC3339, dueDateStr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid due_date format (expected RFC3339): %w", err)
+		}
+		opt.Deadline = &dueDate
+	}
+
+	issue, _, err := impl.Client.CreateIssue(owner, repo, opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create issue: %w", err)
+	}
+
+	return textResult((&types.Issue{Issue: issue}).ToMarkdown()), nil, nil
+}
+
+func (impl CreateImpl) createIssueComment(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionCreate, "issue_comment", err.Error()))
+	}
+
+	index, ok := args["index"].(float64)
+	if !ok || index <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionCreate, "issue_comment", "index is required"))
+	}
+
+	body, _ := args["body"].(string)
+	if body == "" {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionCreate, "issue_comment", "body is required"))
+	}
+
+	opt := forgejo.CreateIssueCommentOption{Body: body}
+	comment, _, err := impl.Client.CreateIssueComment(owner, repo, int64(index), opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create comment: %w", err)
+	}
+
+	return textResult((&types.Comment{Comment: comment}).ToMarkdown()), nil, nil
+}
+
+func (impl CreateImpl) createLabel(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionCreate, "label", err.Error()))
+	}
+
+	name, _ := args["name"].(string)
+	if name == "" {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionCreate, "label", "name is required"))
+	}
+
+	color, _ := args["color"].(string)
+	if color == "" {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionCreate, "label", "color is required"))
+	}
+
+	description, _ := args["description"].(string)
+
+	opt := forgejo.CreateLabelOption{
+		Name:        name,
+		Color:       color,
+		Description: description,
+	}
+
+	label, _, err := impl.Client.CreateLabel(owner, repo, opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create label: %w", err)
+	}
+
+	return textResult((&types.Label{Label: label}).ToMarkdown()), nil, nil
+}
+
+func (impl CreateImpl) createMilestone(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionCreate, "milestone", err.Error()))
+	}
+
+	title, _ := args["title"].(string)
+	if title == "" {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionCreate, "milestone", "title is required"))
+	}
+
+	description, _ := args["description"].(string)
+
+	opt := forgejo.CreateMilestoneOption{
+		Title:       title,
+		Description: description,
+	}
+
+	if dueDateStr, ok := args["due_date"].(string); ok && dueDateStr != "" {
+		dueDate, err := time.Parse(time.RFC3339, dueDateStr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid due_date format (expected RFC3339): %w", err)
+		}
+		opt.Deadline = &dueDate
+	}
+
+	milestone, _, err := impl.Client.CreateMilestone(owner, repo, opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create milestone: %w", err)
+	}
+
+	return textResult((&types.Milestone{Milestone: milestone}).ToMarkdown()), nil, nil
+}
+
+func (impl CreateImpl) createRelease(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionCreate, "release", err.Error()))
+	}
+
+	tagName, _ := args["tag_name"].(string)
+	if tagName == "" {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionCreate, "release", "tag_name is required"))
+	}
+
+	name, _ := args["name"].(string)
+	if name == "" {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionCreate, "release", "name is required"))
+	}
+
+	opt := forgejo.CreateReleaseOption{
+		TagName: tagName,
+		Title:   name,
+	}
+
+	if body, ok := args["body"].(string); ok {
+		opt.Note = body
+	}
+	if target, ok := args["target_commitish"].(string); ok {
+		opt.Target = target
+	}
+	if draft, ok := args["draft"].(bool); ok {
+		opt.IsDraft = draft
+	}
+	if prerelease, ok := args["prerelease"].(bool); ok {
+		opt.IsPrerelease = prerelease
+	}
+
+	release, _, err := impl.Client.CreateRelease(owner, repo, opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create release: %w", err)
+	}
+
+	return textResult((&types.Release{Release: release}).ToMarkdown()), nil, nil
+}
+
+func (impl CreateImpl) createWikiPage(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionCreate, "wiki_page", err.Error()))
+	}
+
+	title, _ := args["title"].(string)
+	if title == "" {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionCreate, "wiki_page", "title is required"))
+	}
+
+	content, _ := args["content"].(string)
+	if content == "" {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionCreate, "wiki_page", "content is required"))
+	}
+
+	message, _ := args["message"].(string)
+
+	options := types.MyCreateWikiPageOptions{
+		Title:         title,
+		ContentBase64: base64.StdEncoding.EncodeToString([]byte(content)),
+		Message:       message,
+	}
+
+	page, err := impl.Client.MyCreateWikiPage(owner, repo, options)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create wiki page: %w", err)
+	}
+
+	return textResult((&types.WikiPage{MyWikiPage: page}).ToMarkdown()), nil, nil
+}
+
+func (impl CreateImpl) createPullRequest(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionCreate, "pull_request", err.Error()))
+	}
+
+	title, _ := args["title"].(string)
+	if title == "" {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionCreate, "pull_request", "title is required"))
+	}
+
+	head, _ := args["head"].(string)
+	if head == "" {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionCreate, "pull_request", "head is required"))
+	}
+
+	base, _ := args["base"].(string)
+	if base == "" {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionCreate, "pull_request", "base is required"))
+	}
+
+	opt := forgejo.CreatePullRequestOption{
+		Title: title,
+		Head:  head,
+		Base:  base,
+	}
+
+	if body, ok := args["body"].(string); ok {
+		opt.Body = body
+	}
+	if assignees, ok := args["assignees"].([]any); ok {
+		opt.Assignees = toStringSlice(assignees)
+	}
+	if milestone, ok := args["milestone"].(float64); ok && milestone > 0 {
+		opt.Milestone = int64(milestone)
+	}
+	if labels, ok := args["labels"].([]any); ok {
+		opt.Labels = toInt64Slice(labels)
+	}
+
+	pr, _, err := impl.Client.CreatePullRequest(owner, repo, opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create pull request: %w", err)
+	}
+
+	return textResult((&types.PullRequest{PullRequest: pr}).ToMarkdown()), nil, nil
+}
+
+// Helper functions
+
+func extractOwnerRepo(args map[string]any) (string, string, error) {
+	owner, _ := args["owner"].(string)
+	repo, _ := args["repo"].(string)
+	if owner == "" {
+		return "", "", fmt.Errorf("owner is required")
+	}
+	if repo == "" {
+		return "", "", fmt.Errorf("repo is required")
+	}
+	return owner, repo, nil
+}
+
+func toStringSlice(arr []any) []string {
+	result := make([]string, 0, len(arr))
+	for _, v := range arr {
+		if s, ok := v.(string); ok {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+func toInt64Slice(arr []any) []int64 {
+	result := make([]int64, 0, len(arr))
+	for _, v := range arr {
+		if f, ok := v.(float64); ok {
+			result = append(result, int64(f))
+		}
+	}
+	return result
+}
+
+func textResult(text string) *mcp.CallToolResult {
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: text},
+		},
+	}
+}

--- a/tools/unified/delete.go
+++ b/tools/unified/delete.go
@@ -1,0 +1,240 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright © 2025 Ronmi Ren <ronmi.ren@gmail.com>
+
+package unified
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/raohwork/forgejo-mcp/tools"
+	"github.com/raohwork/forgejo-mcp/types"
+)
+
+// DeleteImpl implements the delete_gitea tool.
+type DeleteImpl struct {
+	Client *tools.Client
+}
+
+// Definition describes the delete_gitea tool with minimal schema.
+func (DeleteImpl) Definition() *mcp.Tool {
+	return &mcp.Tool{
+		Name:  "delete_gitea",
+		Title: "Delete Gitea Resource",
+		Description: `Delete a resource from Forgejo/Gitea. This action cannot be undone.
+Resources: issue_comment, issue_attachment, label, milestone, release, release_attachment, wiki_page.
+Use gitea_manual(action="delete") for details.`,
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:    false,
+			DestructiveHint: tools.BoolPtr(true),
+			IdempotentHint:  true,
+		},
+		InputSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"resource": {
+					Type:        "string",
+					Description: "Resource type to delete",
+					Enum: []any{
+						"issue_comment", "issue_attachment", "label",
+						"milestone", "release", "release_attachment", "wiki_page",
+					},
+				},
+				"owner": {
+					Type:        "string",
+					Description: "Repository owner",
+				},
+				"repo": {
+					Type:        "string",
+					Description: "Repository name",
+				},
+			},
+			Required:             []string{"resource", "owner", "repo"},
+			AdditionalProperties: &jsonschema.Schema{},
+		},
+	}
+}
+
+// Handler dispatches to the appropriate delete logic based on resource type.
+func (impl DeleteImpl) Handler() mcp.ToolHandlerFor[map[string]any, any] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+		resource, _ := args["resource"].(string)
+		if resource == "" {
+			resources := ListResourcesForAction(ActionDelete)
+			return nil, nil, fmt.Errorf("resource is required. Valid resources: %v", resources)
+		}
+
+		if _, ok := LookupManual(ActionDelete, resource); !ok {
+			resources := ListResourcesForAction(ActionDelete)
+			return nil, nil, fmt.Errorf("unknown resource '%s'. Valid resources: %v", resource, resources)
+		}
+
+		switch resource {
+		case "issue_comment":
+			return impl.deleteIssueComment(args)
+		case "issue_attachment":
+			return impl.deleteIssueAttachment(args)
+		case "label":
+			return impl.deleteLabel(args)
+		case "milestone":
+			return impl.deleteMilestone(args)
+		case "release":
+			return impl.deleteRelease(args)
+		case "release_attachment":
+			return impl.deleteReleaseAttachment(args)
+		case "wiki_page":
+			return impl.deleteWikiPage(args)
+		default:
+			return nil, nil, fmt.Errorf(FormatValidationError(ActionDelete, resource, "not implemented"))
+		}
+	}
+}
+
+func (impl DeleteImpl) deleteIssueComment(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionDelete, "issue_comment", err.Error()))
+	}
+
+	id, ok := args["id"].(float64)
+	if !ok || id <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionDelete, "issue_comment", "id is required"))
+	}
+
+	_, err = impl.Client.DeleteIssueComment(owner, repo, int64(id))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to delete comment: %w", err)
+	}
+
+	return textResult(fmt.Sprintf("Comment %d successfully deleted.", int64(id))), nil, nil
+}
+
+func (impl DeleteImpl) deleteIssueAttachment(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionDelete, "issue_attachment", err.Error()))
+	}
+
+	index, ok := args["index"].(float64)
+	if !ok || index <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionDelete, "issue_attachment", "index is required"))
+	}
+
+	attachmentID, ok := args["attachment_id"].(float64)
+	if !ok || attachmentID <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionDelete, "issue_attachment", "attachment_id is required"))
+	}
+
+	err = impl.Client.MyDeleteIssueAttachment(owner, repo, int64(index), int64(attachmentID))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to delete attachment: %w", err)
+	}
+
+	return textResult(types.EmptyResponse{}.ToMarkdown()), nil, nil
+}
+
+func (impl DeleteImpl) deleteLabel(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionDelete, "label", err.Error()))
+	}
+
+	id, ok := args["id"].(float64)
+	if !ok || id <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionDelete, "label", "id is required"))
+	}
+
+	_, err = impl.Client.DeleteLabel(owner, repo, int64(id))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to delete label: %w", err)
+	}
+
+	return textResult(types.EmptyResponse{}.ToMarkdown()), nil, nil
+}
+
+func (impl DeleteImpl) deleteMilestone(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionDelete, "milestone", err.Error()))
+	}
+
+	id, ok := args["id"].(float64)
+	if !ok || id <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionDelete, "milestone", "id is required"))
+	}
+
+	_, err = impl.Client.DeleteMilestone(owner, repo, int64(id))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to delete milestone: %w", err)
+	}
+
+	return textResult(types.EmptyResponse{}.ToMarkdown()), nil, nil
+}
+
+func (impl DeleteImpl) deleteRelease(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionDelete, "release", err.Error()))
+	}
+
+	id, ok := args["id"].(float64)
+	if !ok || id <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionDelete, "release", "id is required"))
+	}
+
+	_, err = impl.Client.DeleteRelease(owner, repo, int64(id))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to delete release: %w", err)
+	}
+
+	return textResult(types.EmptyResponse{}.ToMarkdown()), nil, nil
+}
+
+func (impl DeleteImpl) deleteReleaseAttachment(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionDelete, "release_attachment", err.Error()))
+	}
+
+	id, ok := args["id"].(float64)
+	if !ok || id <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionDelete, "release_attachment", "id is required"))
+	}
+
+	attachmentID, ok := args["attachment_id"].(float64)
+	if !ok || attachmentID <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionDelete, "release_attachment", "attachment_id is required"))
+	}
+
+	_, err = impl.Client.DeleteReleaseAttachment(owner, repo, int64(id), int64(attachmentID))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to delete release attachment: %w", err)
+	}
+
+	return textResult(types.EmptyResponse{}.ToMarkdown()), nil, nil
+}
+
+func (impl DeleteImpl) deleteWikiPage(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionDelete, "wiki_page", err.Error()))
+	}
+
+	pageName, _ := args["page_name"].(string)
+	if pageName == "" {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionDelete, "wiki_page", "page_name is required"))
+	}
+
+	err = impl.Client.MyDeleteWikiPage(owner, repo, pageName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to delete wiki page: %w", err)
+	}
+
+	return textResult(types.EmptyResponse{}.ToMarkdown()), nil, nil
+}

--- a/tools/unified/doc.go
+++ b/tools/unified/doc.go
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright © 2025 Ronmi Ren <ronmi.ren@gmail.com>
+
+// Package unified provides a consolidated MCP toolset for Forgejo/Gitea operations.
+//
+// This package implements an action-based tool architecture that reduces token
+// consumption by ~80% compared to resource-based tools. Instead of separate tools
+// for each operation on each resource type (e.g., create_issue, create_label,
+// create_milestone), this package provides unified action tools:
+//
+//   - create_gitea: Create resources (issues, labels, milestones, releases, etc.)
+//   - get_gitea: Get single resources by ID/name
+//   - list_gitea: List resources with filtering
+//   - edit_gitea: Edit existing resources
+//   - delete_gitea: Delete resources
+//   - link_gitea: Create relationships (issue↔label, issue↔issue dependencies)
+//   - unlink_gitea: Remove relationships
+//   - gitea_manual: On-demand documentation lookup
+//
+// Design Philosophy:
+//
+// The toolset relies on LLM implicit knowledge about git forge concepts (issues,
+// labels, milestones, etc.) to keep tool definitions minimal. Detailed documentation
+// is provided through:
+//
+//  1. The gitea_manual tool for proactive lookup
+//  2. Rich error messages when validation fails
+//
+// This "lazy-loaded documentation" approach means tokens are only spent on
+// documentation the LLM actually needs.
+package unified

--- a/tools/unified/edit.go
+++ b/tools/unified/edit.go
@@ -1,0 +1,376 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright © 2025 Ronmi Ren <ronmi.ren@gmail.com>
+
+package unified
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	"codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v2"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/raohwork/forgejo-mcp/tools"
+	"github.com/raohwork/forgejo-mcp/types"
+)
+
+// EditImpl implements the edit_gitea tool.
+type EditImpl struct {
+	Client *tools.Client
+}
+
+// Definition describes the edit_gitea tool with minimal schema.
+func (EditImpl) Definition() *mcp.Tool {
+	return &mcp.Tool{
+		Name:  "edit_gitea",
+		Title: "Edit Gitea Resource",
+		Description: `Edit an existing resource in Forgejo/Gitea.
+Resources: issue, issue_comment, issue_attachment, label, milestone, release, release_attachment, wiki_page.
+Use gitea_manual(action="edit") for details.`,
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:    false,
+			DestructiveHint: tools.BoolPtr(false),
+			IdempotentHint:  true,
+		},
+		InputSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"resource": {
+					Type:        "string",
+					Description: "Resource type to edit",
+					Enum: []any{
+						"issue", "issue_comment", "issue_attachment", "label",
+						"milestone", "release", "release_attachment", "wiki_page",
+					},
+				},
+				"owner": {
+					Type:        "string",
+					Description: "Repository owner",
+				},
+				"repo": {
+					Type:        "string",
+					Description: "Repository name",
+				},
+			},
+			Required:             []string{"resource", "owner", "repo"},
+			AdditionalProperties: &jsonschema.Schema{},
+		},
+	}
+}
+
+// Handler dispatches to the appropriate edit logic based on resource type.
+func (impl EditImpl) Handler() mcp.ToolHandlerFor[map[string]any, any] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+		resource, _ := args["resource"].(string)
+		if resource == "" {
+			resources := ListResourcesForAction(ActionEdit)
+			return nil, nil, fmt.Errorf("resource is required. Valid resources: %v", resources)
+		}
+
+		if _, ok := LookupManual(ActionEdit, resource); !ok {
+			resources := ListResourcesForAction(ActionEdit)
+			return nil, nil, fmt.Errorf("unknown resource '%s'. Valid resources: %v", resource, resources)
+		}
+
+		switch resource {
+		case "issue":
+			return impl.editIssue(args)
+		case "issue_comment":
+			return impl.editIssueComment(args)
+		case "issue_attachment":
+			return impl.editIssueAttachment(args)
+		case "label":
+			return impl.editLabel(args)
+		case "milestone":
+			return impl.editMilestone(args)
+		case "release":
+			return impl.editRelease(args)
+		case "release_attachment":
+			return impl.editReleaseAttachment(args)
+		case "wiki_page":
+			return impl.editWikiPage(args)
+		default:
+			return nil, nil, fmt.Errorf(FormatValidationError(ActionEdit, resource, "not implemented"))
+		}
+	}
+}
+
+func (impl EditImpl) editIssue(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionEdit, "issue", err.Error()))
+	}
+
+	index, ok := args["index"].(float64)
+	if !ok || index <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionEdit, "issue", "index is required"))
+	}
+
+	opt := forgejo.EditIssueOption{}
+
+	if title, ok := args["title"].(string); ok && title != "" {
+		opt.Title = title
+	}
+	if body, ok := args["body"].(string); ok && body != "" {
+		opt.Body = &body
+	}
+	if state, ok := args["state"].(string); ok && state != "" {
+		s := forgejo.StateType(state)
+		opt.State = &s
+	}
+	if assignees, ok := args["assignees"].([]any); ok {
+		opt.Assignees = toStringSlice(assignees)
+	}
+	if milestone, ok := args["milestone"].(float64); ok && milestone > 0 {
+		m := int64(milestone)
+		opt.Milestone = &m
+	}
+	if dueDateStr, ok := args["due_date"].(string); ok && dueDateStr != "" {
+		dueDate, err := time.Parse(time.RFC3339, dueDateStr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid due_date format (expected RFC3339): %w", err)
+		}
+		opt.Deadline = &dueDate
+	}
+
+	issue, _, err := impl.Client.EditIssue(owner, repo, int64(index), opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to edit issue: %w", err)
+	}
+
+	return textResult((&types.Issue{Issue: issue}).ToMarkdown()), nil, nil
+}
+
+func (impl EditImpl) editIssueComment(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionEdit, "issue_comment", err.Error()))
+	}
+
+	id, ok := args["id"].(float64)
+	if !ok || id <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionEdit, "issue_comment", "id is required"))
+	}
+
+	body, _ := args["body"].(string)
+	if body == "" {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionEdit, "issue_comment", "body is required"))
+	}
+
+	opt := forgejo.EditIssueCommentOption{Body: body}
+	comment, _, err := impl.Client.EditIssueComment(owner, repo, int64(id), opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to edit comment: %w", err)
+	}
+
+	return textResult((&types.Comment{Comment: comment}).ToMarkdown()), nil, nil
+}
+
+func (impl EditImpl) editIssueAttachment(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionEdit, "issue_attachment", err.Error()))
+	}
+
+	index, ok := args["index"].(float64)
+	if !ok || index <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionEdit, "issue_attachment", "index is required"))
+	}
+
+	attachmentID, ok := args["attachment_id"].(float64)
+	if !ok || attachmentID <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionEdit, "issue_attachment", "attachment_id is required"))
+	}
+
+	name, _ := args["name"].(string)
+	if name == "" {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionEdit, "issue_attachment", "name is required"))
+	}
+
+	options := tools.MyEditAttachmentOptions{Name: name}
+	attachment, err := impl.Client.MyEditIssueAttachment(owner, repo, int64(index), int64(attachmentID), options)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to edit attachment: %w", err)
+	}
+
+	return textResult((&types.Attachment{Attachment: attachment}).ToMarkdown()), nil, nil
+}
+
+func (impl EditImpl) editLabel(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionEdit, "label", err.Error()))
+	}
+
+	id, ok := args["id"].(float64)
+	if !ok || id <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionEdit, "label", "id is required"))
+	}
+
+	opt := forgejo.EditLabelOption{}
+	if name, ok := args["name"].(string); ok && name != "" {
+		opt.Name = &name
+	}
+	if color, ok := args["color"].(string); ok && color != "" {
+		opt.Color = &color
+	}
+	if description, ok := args["description"].(string); ok && description != "" {
+		opt.Description = &description
+	}
+
+	label, _, err := impl.Client.EditLabel(owner, repo, int64(id), opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to edit label: %w", err)
+	}
+
+	return textResult((&types.Label{Label: label}).ToMarkdown()), nil, nil
+}
+
+func (impl EditImpl) editMilestone(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionEdit, "milestone", err.Error()))
+	}
+
+	id, ok := args["id"].(float64)
+	if !ok || id <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionEdit, "milestone", "id is required"))
+	}
+
+	opt := forgejo.EditMilestoneOption{}
+	if title, ok := args["title"].(string); ok && title != "" {
+		opt.Title = title
+	}
+	if description, ok := args["description"].(string); ok && description != "" {
+		opt.Description = &description
+	}
+	if state, ok := args["state"].(string); ok && state != "" {
+		s := forgejo.StateType(state)
+		opt.State = &s
+	}
+	if dueDateStr, ok := args["due_date"].(string); ok && dueDateStr != "" {
+		dueDate, err := time.Parse(time.RFC3339, dueDateStr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid due_date format (expected RFC3339): %w", err)
+		}
+		opt.Deadline = &dueDate
+	}
+
+	milestone, _, err := impl.Client.EditMilestone(owner, repo, int64(id), opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to edit milestone: %w", err)
+	}
+
+	return textResult((&types.Milestone{Milestone: milestone}).ToMarkdown()), nil, nil
+}
+
+func (impl EditImpl) editRelease(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionEdit, "release", err.Error()))
+	}
+
+	id, ok := args["id"].(float64)
+	if !ok || id <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionEdit, "release", "id is required"))
+	}
+
+	opt := forgejo.EditReleaseOption{}
+	if tagName, ok := args["tag_name"].(string); ok && tagName != "" {
+		opt.TagName = tagName
+	}
+	if target, ok := args["target_commitish"].(string); ok && target != "" {
+		opt.Target = target
+	}
+	if name, ok := args["name"].(string); ok && name != "" {
+		opt.Title = name
+	}
+	if body, ok := args["body"].(string); ok && body != "" {
+		opt.Note = body
+	}
+	if draft, ok := args["draft"].(bool); ok {
+		opt.IsDraft = &draft
+	}
+	if prerelease, ok := args["prerelease"].(bool); ok {
+		opt.IsPrerelease = &prerelease
+	}
+
+	release, _, err := impl.Client.EditRelease(owner, repo, int64(id), opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to edit release: %w", err)
+	}
+
+	return textResult((&types.Release{Release: release}).ToMarkdown()), nil, nil
+}
+
+func (impl EditImpl) editReleaseAttachment(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionEdit, "release_attachment", err.Error()))
+	}
+
+	id, ok := args["id"].(float64)
+	if !ok || id <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionEdit, "release_attachment", "id is required"))
+	}
+
+	attachmentID, ok := args["attachment_id"].(float64)
+	if !ok || attachmentID <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionEdit, "release_attachment", "attachment_id is required"))
+	}
+
+	name, _ := args["name"].(string)
+	if name == "" {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionEdit, "release_attachment", "name is required"))
+	}
+
+	opt := forgejo.EditAttachmentOptions{Name: name}
+	attachment, _, err := impl.Client.EditReleaseAttachment(owner, repo, int64(id), int64(attachmentID), opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to edit release attachment: %w", err)
+	}
+
+	return textResult((&types.Attachment{Attachment: attachment}).ToMarkdown()), nil, nil
+}
+
+func (impl EditImpl) editWikiPage(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionEdit, "wiki_page", err.Error()))
+	}
+
+	pageName, _ := args["page_name"].(string)
+	if pageName == "" {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionEdit, "wiki_page", "page_name is required"))
+	}
+
+	content, _ := args["content"].(string)
+	if content == "" {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionEdit, "wiki_page", "content is required"))
+	}
+
+	title, _ := args["title"].(string)
+	if title == "" {
+		title = pageName
+	}
+	message, _ := args["message"].(string)
+
+	options := types.MyCreateWikiPageOptions{
+		Title:         title,
+		ContentBase64: base64.StdEncoding.EncodeToString([]byte(content)),
+		Message:       message,
+	}
+
+	page, err := impl.Client.MyEditWikiPage(owner, repo, pageName, options)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to edit wiki page: %w", err)
+	}
+
+	return textResult((&types.WikiPage{MyWikiPage: page}).ToMarkdown()), nil, nil
+}

--- a/tools/unified/get.go
+++ b/tools/unified/get.go
@@ -1,0 +1,158 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright © 2025 Ronmi Ren <ronmi.ren@gmail.com>
+
+package unified
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/raohwork/forgejo-mcp/tools"
+	"github.com/raohwork/forgejo-mcp/types"
+)
+
+// GetImpl implements the get_gitea tool.
+type GetImpl struct {
+	Client *tools.Client
+}
+
+// Definition describes the get_gitea tool with minimal schema.
+func (GetImpl) Definition() *mcp.Tool {
+	return &mcp.Tool{
+		Name:  "get_gitea",
+		Title: "Get Gitea Resource",
+		Description: `Get details of a single resource from Forgejo/Gitea.
+Resources: issue, wiki_page, pull_request, repository.
+Use gitea_manual(action="get") for details.`,
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:   true,
+			IdempotentHint: true,
+		},
+		InputSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"resource": {
+					Type:        "string",
+					Description: "Resource type to get",
+					Enum:        []any{"issue", "wiki_page", "pull_request", "repository"},
+				},
+				"owner": {
+					Type:        "string",
+					Description: "Repository owner",
+				},
+				"repo": {
+					Type:        "string",
+					Description: "Repository name",
+				},
+			},
+			Required:             []string{"resource", "owner", "repo"},
+			AdditionalProperties: &jsonschema.Schema{},
+		},
+	}
+}
+
+// Handler dispatches to the appropriate get logic based on resource type.
+func (impl GetImpl) Handler() mcp.ToolHandlerFor[map[string]any, any] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+		resource, _ := args["resource"].(string)
+		if resource == "" {
+			resources := ListResourcesForAction(ActionGet)
+			return nil, nil, fmt.Errorf("resource is required. Valid resources: %v", resources)
+		}
+
+		if _, ok := LookupManual(ActionGet, resource); !ok {
+			resources := ListResourcesForAction(ActionGet)
+			return nil, nil, fmt.Errorf("unknown resource '%s'. Valid resources: %v", resource, resources)
+		}
+
+		switch resource {
+		case "issue":
+			return impl.getIssue(args)
+		case "wiki_page":
+			return impl.getWikiPage(args)
+		case "pull_request":
+			return impl.getPullRequest(args)
+		case "repository":
+			return impl.getRepository(args)
+		default:
+			return nil, nil, fmt.Errorf(FormatValidationError(ActionGet, resource, "not implemented"))
+		}
+	}
+}
+
+func (impl GetImpl) getIssue(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionGet, "issue", err.Error()))
+	}
+
+	index, ok := args["index"].(float64)
+	if !ok || index <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionGet, "issue", "index is required"))
+	}
+
+	issue, _, err := impl.Client.GetIssue(owner, repo, int64(index))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get issue: %w", err)
+	}
+
+	return textResult((&types.Issue{Issue: issue}).ToMarkdown()), nil, nil
+}
+
+func (impl GetImpl) getWikiPage(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionGet, "wiki_page", err.Error()))
+	}
+
+	pageName, _ := args["page_name"].(string)
+	if pageName == "" {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionGet, "wiki_page", "page_name is required"))
+	}
+
+	page, err := impl.Client.MyGetWikiPage(owner, repo, pageName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get wiki page: %w", err)
+	}
+
+	return textResult((&types.WikiPage{MyWikiPage: page}).ToMarkdown()), nil, nil
+}
+
+func (impl GetImpl) getPullRequest(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionGet, "pull_request", err.Error()))
+	}
+
+	index, ok := args["index"].(float64)
+	if !ok || index <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionGet, "pull_request", "index is required"))
+	}
+
+	pr, _, err := impl.Client.GetPullRequest(owner, repo, int64(index))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get pull request: %w", err)
+	}
+
+	return textResult((&types.PullRequest{PullRequest: pr}).ToMarkdown()), nil, nil
+}
+
+func (impl GetImpl) getRepository(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionGet, "repository", err.Error()))
+	}
+
+	repository, _, err := impl.Client.GetRepo(owner, repo)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get repository: %w", err)
+	}
+
+	return textResult((&types.Repository{Repository: repository}).ToMarkdown()), nil, nil
+}

--- a/tools/unified/link.go
+++ b/tools/unified/link.go
@@ -1,0 +1,178 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright © 2025 Ronmi Ren <ronmi.ren@gmail.com>
+
+package unified
+
+import (
+	"context"
+	"fmt"
+
+	"codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v2"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/raohwork/forgejo-mcp/tools"
+	"github.com/raohwork/forgejo-mcp/types"
+)
+
+// LinkImpl implements the link_gitea tool.
+type LinkImpl struct {
+	Client *tools.Client
+}
+
+// Definition describes the link_gitea tool with minimal schema.
+func (LinkImpl) Definition() *mcp.Tool {
+	return &mcp.Tool{
+		Name:  "link_gitea",
+		Title: "Link Gitea Resources",
+		Description: `Create relationships between resources in Forgejo/Gitea.
+Types: issue_label (add labels to issue), issue_dependency (issue depends on another), issue_blocking (issue blocks another).
+Use gitea_manual(action="link") for details.`,
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:    false,
+			DestructiveHint: tools.BoolPtr(false),
+			IdempotentHint:  true,
+		},
+		InputSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"type": {
+					Type:        "string",
+					Description: "Link type",
+					Enum:        []any{"issue_label", "issue_dependency", "issue_blocking"},
+				},
+				"owner": {
+					Type:        "string",
+					Description: "Repository owner",
+				},
+				"repo": {
+					Type:        "string",
+					Description: "Repository name",
+				},
+			},
+			Required:             []string{"type", "owner", "repo"},
+			AdditionalProperties: &jsonschema.Schema{},
+		},
+	}
+}
+
+// Handler dispatches to the appropriate link logic based on type.
+func (impl LinkImpl) Handler() mcp.ToolHandlerFor[map[string]any, any] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+		linkType, _ := args["type"].(string)
+		if linkType == "" {
+			return nil, nil, fmt.Errorf("type is required. Valid types: %v", ListLinkTypes())
+		}
+
+		if _, ok := LookupManual(ActionLink, linkType); !ok {
+			return nil, nil, fmt.Errorf("unknown type '%s'. Valid types: %v", linkType, ListLinkTypes())
+		}
+
+		switch linkType {
+		case "issue_label":
+			return impl.addIssueLabels(args)
+		case "issue_dependency":
+			return impl.addIssueDependency(args)
+		case "issue_blocking":
+			return impl.addIssueBlocking(args)
+		default:
+			return nil, nil, fmt.Errorf(FormatValidationError(ActionLink, linkType, "not implemented"))
+		}
+	}
+}
+
+func (impl LinkImpl) addIssueLabels(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionLink, "issue_label", err.Error()))
+	}
+
+	index, ok := args["index"].(float64)
+	if !ok || index <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionLink, "issue_label", "index is required"))
+	}
+
+	labelsRaw, ok := args["labels"].([]any)
+	if !ok || len(labelsRaw) == 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionLink, "issue_label", "labels is required (array of label IDs)"))
+	}
+
+	labelIDs := toInt64Slice(labelsRaw)
+	opt := forgejo.IssueLabelsOption{Labels: labelIDs}
+
+	labels, _, err := impl.Client.AddIssueLabels(owner, repo, int64(index), opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to add labels: %w", err)
+	}
+
+	labelList := make(types.LabelList, len(labels))
+	for i, l := range labels {
+		labelList[i] = &types.Label{Label: l}
+	}
+	return textResult(fmt.Sprintf("Labels added to issue #%d\n\n%s", int(index), labelList.ToMarkdown())), nil, nil
+}
+
+func (impl LinkImpl) addIssueDependency(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionLink, "issue_dependency", err.Error()))
+	}
+
+	index, ok := args["index"].(float64)
+	if !ok || index <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionLink, "issue_dependency", "index is required"))
+	}
+
+	dependencyIndex, ok := args["dependency_index"].(float64)
+	if !ok || dependencyIndex <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionLink, "issue_dependency", "dependency_index is required"))
+	}
+
+	dependency := types.MyIssueMeta{
+		Owner: owner,
+		Name:  repo,
+		Index: int64(dependencyIndex),
+	}
+
+	_, err = impl.Client.MyAddIssueDependency(owner, repo, int64(index), dependency)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to add dependency: %w", err)
+	}
+
+	return textResult(fmt.Sprintf("Issue #%d now depends on issue #%d (must close #%d first)",
+		int(index), int(dependencyIndex), int(dependencyIndex))), nil, nil
+}
+
+func (impl LinkImpl) addIssueBlocking(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionLink, "issue_blocking", err.Error()))
+	}
+
+	index, ok := args["index"].(float64)
+	if !ok || index <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionLink, "issue_blocking", "index is required"))
+	}
+
+	blockedIndex, ok := args["blocked_index"].(float64)
+	if !ok || blockedIndex <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionLink, "issue_blocking", "blocked_index is required"))
+	}
+
+	blocked := types.MyIssueMeta{
+		Owner: owner,
+		Name:  repo,
+		Index: int64(blockedIndex),
+	}
+
+	_, err = impl.Client.MyAddIssueBlocking(owner, repo, int64(index), blocked)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to add blocking relationship: %w", err)
+	}
+
+	return textResult(fmt.Sprintf("Issue #%d now blocks issue #%d (must close #%d first)",
+		int(index), int(blockedIndex), int(index))), nil, nil
+}

--- a/tools/unified/list.go
+++ b/tools/unified/list.go
@@ -1,0 +1,576 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright © 2025 Ronmi Ren <ronmi.ren@gmail.com>
+
+package unified
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v2"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/raohwork/forgejo-mcp/tools"
+	"github.com/raohwork/forgejo-mcp/types"
+)
+
+// ListImpl implements the list_gitea tool.
+type ListImpl struct {
+	Client *tools.Client
+}
+
+// Definition describes the list_gitea tool with minimal schema.
+func (ListImpl) Definition() *mcp.Tool {
+	return &mcp.Tool{
+		Name:  "list_gitea",
+		Title: "List Gitea Resources",
+		Description: `List resources from Forgejo/Gitea with filtering.
+Resources: issue, issue_comment, issue_attachment, label, milestone, release, release_attachment, wiki_page, pull_request, repository, action_task, issue_dependency, issue_blocking.
+Use gitea_manual(action="list") for details.`,
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:   true,
+			IdempotentHint: true,
+		},
+		InputSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"resource": {
+					Type:        "string",
+					Description: "Resource type to list",
+					Enum: []any{
+						"issue", "issue_comment", "issue_attachment", "label",
+						"milestone", "release", "release_attachment", "wiki_page",
+						"pull_request", "repository", "action_task",
+						"issue_dependency", "issue_blocking",
+					},
+				},
+				"owner": {
+					Type:        "string",
+					Description: "Repository owner (not required for repository with scope='my')",
+				},
+				"repo": {
+					Type:        "string",
+					Description: "Repository name (not required for repository listing)",
+				},
+			},
+			Required:             []string{"resource"},
+			AdditionalProperties: &jsonschema.Schema{},
+		},
+	}
+}
+
+// Handler dispatches to the appropriate list logic based on resource type.
+func (impl ListImpl) Handler() mcp.ToolHandlerFor[map[string]any, any] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+		resource, _ := args["resource"].(string)
+		if resource == "" {
+			resources := ListResourcesForAction(ActionList)
+			return nil, nil, fmt.Errorf("resource is required. Valid resources: %v", resources)
+		}
+
+		if _, ok := LookupManual(ActionList, resource); !ok {
+			resources := ListResourcesForAction(ActionList)
+			return nil, nil, fmt.Errorf("unknown resource '%s'. Valid resources: %v", resource, resources)
+		}
+
+		switch resource {
+		case "issue":
+			return impl.listIssues(args)
+		case "issue_comment":
+			return impl.listIssueComments(args)
+		case "issue_attachment":
+			return impl.listIssueAttachments(args)
+		case "label":
+			return impl.listLabels(args)
+		case "milestone":
+			return impl.listMilestones(args)
+		case "release":
+			return impl.listReleases(args)
+		case "release_attachment":
+			return impl.listReleaseAttachments(args)
+		case "wiki_page":
+			return impl.listWikiPages(args)
+		case "pull_request":
+			return impl.listPullRequests(args)
+		case "repository":
+			return impl.listRepositories(args)
+		case "action_task":
+			return impl.listActionTasks(args)
+		case "issue_dependency":
+			return impl.listIssueDependencies(args)
+		case "issue_blocking":
+			return impl.listIssueBlocking(args)
+		default:
+			return nil, nil, fmt.Errorf(FormatValidationError(ActionList, resource, "not implemented"))
+		}
+	}
+}
+
+func (impl ListImpl) listIssues(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionList, "issue", err.Error()))
+	}
+
+	opt := forgejo.ListIssueOption{}
+
+	if state, ok := args["state"].(string); ok && state != "" {
+		opt.State = forgejo.StateType(state)
+	}
+	if labels, ok := args["labels"].(string); ok && labels != "" {
+		opt.Labels = strings.Split(labels, ",")
+	}
+	if milestones, ok := args["milestones"].(string); ok && milestones != "" {
+		opt.Milestones = strings.Split(milestones, ",")
+	}
+	if q, ok := args["q"].(string); ok && q != "" {
+		opt.KeyWord = q
+	}
+	if assignees, ok := args["assignees"].(string); ok && assignees != "" {
+		opt.AssignedBy = assignees
+	}
+	if page, ok := args["page"].(float64); ok && page > 0 {
+		opt.Page = int(page)
+	}
+	if limit, ok := args["limit"].(float64); ok && limit > 0 {
+		opt.PageSize = int(limit)
+	}
+	if sinceStr, ok := args["since"].(string); ok && sinceStr != "" {
+		since, err := time.Parse(time.RFC3339, sinceStr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid since format (expected RFC3339): %w", err)
+		}
+		opt.Since = since
+	}
+	if beforeStr, ok := args["before"].(string); ok && beforeStr != "" {
+		before, err := time.Parse(time.RFC3339, beforeStr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid before format (expected RFC3339): %w", err)
+		}
+		opt.Before = before
+	}
+
+	issues, _, err := impl.Client.ListRepoIssues(owner, repo, opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list issues: %w", err)
+	}
+
+	issueList := types.IssueList(issues)
+	content := fmt.Sprintf("Found %d issues\n\n%s", len(issues), issueList.ToMarkdown())
+	return textResult(content), nil, nil
+}
+
+func (impl ListImpl) listIssueComments(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionList, "issue_comment", err.Error()))
+	}
+
+	index, ok := args["index"].(float64)
+	if !ok || index <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionList, "issue_comment", "index is required"))
+	}
+
+	opt := forgejo.ListIssueCommentOptions{}
+	if sinceStr, ok := args["since"].(string); ok && sinceStr != "" {
+		since, err := time.Parse(time.RFC3339, sinceStr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid since format: %w", err)
+		}
+		opt.Since = since
+	}
+	if beforeStr, ok := args["before"].(string); ok && beforeStr != "" {
+		before, err := time.Parse(time.RFC3339, beforeStr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid before format: %w", err)
+		}
+		opt.Before = before
+	}
+
+	comments, _, err := impl.Client.ListIssueComments(owner, repo, int64(index), opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list comments: %w", err)
+	}
+
+	if len(comments) == 0 {
+		return textResult("No comments found for this issue."), nil, nil
+	}
+
+	var sb strings.Builder
+	for _, comment := range comments {
+		sb.WriteString((&types.Comment{Comment: comment}).ToMarkdown())
+		sb.WriteString("\n\n---\n\n")
+	}
+	return textResult(fmt.Sprintf("Found %d comments\n\n%s", len(comments), sb.String())), nil, nil
+}
+
+func (impl ListImpl) listIssueAttachments(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionList, "issue_attachment", err.Error()))
+	}
+
+	index, ok := args["index"].(float64)
+	if !ok || index <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionList, "issue_attachment", "index is required"))
+	}
+
+	attachments, err := impl.Client.MyListIssueAttachments(owner, repo, int64(index))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list attachments: %w", err)
+	}
+
+	if len(attachments) == 0 {
+		return textResult("No attachments found for this issue."), nil, nil
+	}
+
+	list := make(types.AttachmentList, len(attachments))
+	for i, a := range attachments {
+		list[i] = &types.Attachment{Attachment: a}
+	}
+	return textResult(fmt.Sprintf("Found %d attachments\n\n%s", len(attachments), list.ToMarkdown())), nil, nil
+}
+
+func (impl ListImpl) listLabels(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionList, "label", err.Error()))
+	}
+
+	labels, _, err := impl.Client.ListRepoLabels(owner, repo, forgejo.ListLabelsOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list labels: %w", err)
+	}
+
+	if len(labels) == 0 {
+		return textResult("No labels found in this repository."), nil, nil
+	}
+
+	labelList := make(types.LabelList, len(labels))
+	for i, label := range labels {
+		labelList[i] = &types.Label{Label: label}
+	}
+	return textResult(fmt.Sprintf("Found %d labels\n\n%s", len(labels), labelList.ToMarkdown())), nil, nil
+}
+
+func (impl ListImpl) listMilestones(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionList, "milestone", err.Error()))
+	}
+
+	opt := forgejo.ListMilestoneOption{}
+	if state, ok := args["state"].(string); ok && state != "" {
+		opt.State = forgejo.StateType(state)
+	}
+	if name, ok := args["name"].(string); ok && name != "" {
+		opt.Name = name
+	}
+	if page, ok := args["page"].(float64); ok && page > 0 {
+		opt.Page = int(page)
+	}
+	if limit, ok := args["limit"].(float64); ok && limit > 0 {
+		opt.PageSize = int(limit)
+	}
+
+	milestones, _, err := impl.Client.ListRepoMilestones(owner, repo, opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list milestones: %w", err)
+	}
+
+	if len(milestones) == 0 {
+		return textResult("No milestones found in this repository."), nil, nil
+	}
+
+	milestoneList := make(types.MilestoneList, len(milestones))
+	for i, m := range milestones {
+		milestoneList[i] = &types.Milestone{Milestone: m}
+	}
+	return textResult(fmt.Sprintf("Found %d milestones\n\n%s", len(milestones), milestoneList.ToMarkdown())), nil, nil
+}
+
+func (impl ListImpl) listReleases(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionList, "release", err.Error()))
+	}
+
+	opt := forgejo.ListReleasesOptions{}
+	if page, ok := args["page"].(float64); ok && page > 0 {
+		opt.Page = int(page)
+	}
+	if limit, ok := args["limit"].(float64); ok && limit > 0 {
+		opt.PageSize = int(limit)
+	}
+
+	releases, _, err := impl.Client.ListReleases(owner, repo, opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list releases: %w", err)
+	}
+
+	if len(releases) == 0 {
+		return textResult("No releases found in this repository."), nil, nil
+	}
+
+	releaseList := make(types.ReleaseList, len(releases))
+	for i, r := range releases {
+		releaseList[i] = &types.Release{Release: r}
+	}
+	return textResult(fmt.Sprintf("Found %d releases\n\n%s", len(releases), releaseList.ToMarkdown())), nil, nil
+}
+
+func (impl ListImpl) listReleaseAttachments(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionList, "release_attachment", err.Error()))
+	}
+
+	id, ok := args["id"].(float64)
+	if !ok || id <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionList, "release_attachment", "id is required"))
+	}
+
+	attachments, _, err := impl.Client.ListReleaseAttachments(owner, repo, int64(id), forgejo.ListReleaseAttachmentsOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list release attachments: %w", err)
+	}
+
+	if len(attachments) == 0 {
+		return textResult("No attachments found for this release."), nil, nil
+	}
+
+	list := make(types.AttachmentList, len(attachments))
+	for i, a := range attachments {
+		list[i] = &types.Attachment{Attachment: a}
+	}
+	return textResult(fmt.Sprintf("Found %d attachments\n\n%s", len(attachments), list.ToMarkdown())), nil, nil
+}
+
+func (impl ListImpl) listWikiPages(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionList, "wiki_page", err.Error()))
+	}
+
+	pages, err := impl.Client.MyListWikiPages(owner, repo)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list wiki pages: %w", err)
+	}
+
+	if len(pages) == 0 {
+		return textResult("No wiki pages found in this repository."), nil, nil
+	}
+
+	list := types.WikiPageList(pages)
+	return textResult(fmt.Sprintf("Found %d wiki pages\n\n%s", len(pages), list.ToMarkdown())), nil, nil
+}
+
+func (impl ListImpl) listPullRequests(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionList, "pull_request", err.Error()))
+	}
+
+	opt := forgejo.ListPullRequestsOptions{}
+	if state, ok := args["state"].(string); ok && state != "" {
+		opt.State = forgejo.StateType(state)
+	}
+	if sort, ok := args["sort"].(string); ok && sort != "" {
+		opt.Sort = sort
+	}
+	if milestone, ok := args["milestone"].(float64); ok && milestone > 0 {
+		opt.Milestone = int64(milestone)
+	}
+	if page, ok := args["page"].(float64); ok && page > 0 {
+		opt.Page = int(page)
+	}
+	if limit, ok := args["limit"].(float64); ok && limit > 0 {
+		opt.PageSize = int(limit)
+	}
+
+	prs, _, err := impl.Client.ListRepoPullRequests(owner, repo, opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list pull requests: %w", err)
+	}
+
+	if len(prs) == 0 {
+		return textResult("No pull requests found in this repository."), nil, nil
+	}
+
+	prList := make(types.PullRequestList, len(prs))
+	for i, pr := range prs {
+		prList[i] = &types.PullRequest{PullRequest: pr}
+	}
+	return textResult(fmt.Sprintf("Found %d pull requests\n\n%s", len(prs), prList.ToMarkdown())), nil, nil
+}
+
+func (impl ListImpl) listRepositories(args map[string]any) (*mcp.CallToolResult, any, error) {
+	scope, _ := args["scope"].(string)
+	if scope == "" {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionList, "repository", "scope is required ('my', 'org', or 'search')"))
+	}
+
+	switch scope {
+	case "my":
+		return impl.listMyRepositories(args)
+	case "org":
+		return impl.listOrgRepositories(args)
+	case "search":
+		return impl.searchRepositories(args)
+	default:
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionList, "repository", "scope must be 'my', 'org', or 'search'"))
+	}
+}
+
+func (impl ListImpl) listMyRepositories(args map[string]any) (*mcp.CallToolResult, any, error) {
+	opt := forgejo.ListReposOptions{}
+	if page, ok := args["page"].(float64); ok && page > 0 {
+		opt.Page = int(page)
+	}
+	if limit, ok := args["limit"].(float64); ok && limit > 0 {
+		opt.PageSize = int(limit)
+	}
+
+	repos, _, err := impl.Client.ListMyRepos(opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list my repositories: %w", err)
+	}
+
+	if len(repos) == 0 {
+		return textResult("No repositories found for the authenticated user."), nil, nil
+	}
+
+	repoList := make(types.RepositoryList, len(repos))
+	for i, r := range repos {
+		repoList[i] = &types.Repository{Repository: r}
+	}
+	return textResult(fmt.Sprintf("Found %d repositories\n\n%s", len(repos), repoList.ToMarkdown())), nil, nil
+}
+
+func (impl ListImpl) listOrgRepositories(args map[string]any) (*mcp.CallToolResult, any, error) {
+	org, _ := args["org"].(string)
+	if org == "" {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionList, "repository", "org is required for scope='org'"))
+	}
+
+	opt := forgejo.ListOrgReposOptions{}
+	if page, ok := args["page"].(float64); ok && page > 0 {
+		opt.Page = int(page)
+	}
+	if limit, ok := args["limit"].(float64); ok && limit > 0 {
+		opt.PageSize = int(limit)
+	}
+
+	repos, _, err := impl.Client.ListOrgRepos(org, opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list organization repositories: %w", err)
+	}
+
+	if len(repos) == 0 {
+		return textResult(fmt.Sprintf("No repositories found for organization '%s'.", org)), nil, nil
+	}
+
+	repoList := make(types.RepositoryList, len(repos))
+	for i, r := range repos {
+		repoList[i] = &types.Repository{Repository: r}
+	}
+	return textResult(fmt.Sprintf("Found %d repositories for '%s'\n\n%s", len(repos), org, repoList.ToMarkdown())), nil, nil
+}
+
+func (impl ListImpl) searchRepositories(args map[string]any) (*mcp.CallToolResult, any, error) {
+	q, _ := args["q"].(string)
+
+	opt := forgejo.SearchRepoOptions{Keyword: q}
+	if topic, ok := args["topic"].(bool); ok {
+		opt.KeywordIsTopic = topic
+	}
+	if includeDesc, ok := args["include_desc"].(bool); ok {
+		opt.KeywordInDescription = includeDesc
+	}
+	if page, ok := args["page"].(float64); ok && page > 0 {
+		opt.Page = int(page)
+	}
+	if limit, ok := args["limit"].(float64); ok && limit > 0 {
+		opt.PageSize = int(limit)
+	}
+
+	repos, _, err := impl.Client.SearchRepos(opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to search repositories: %w", err)
+	}
+
+	if len(repos) == 0 {
+		return textResult("No repositories found matching the search criteria."), nil, nil
+	}
+
+	repoList := make(types.RepositoryList, len(repos))
+	for i, r := range repos {
+		repoList[i] = &types.Repository{Repository: r}
+	}
+	return textResult(fmt.Sprintf("Found %d repositories\n\n%s", len(repos), repoList.ToMarkdown())), nil, nil
+}
+
+func (impl ListImpl) listActionTasks(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionList, "action_task", err.Error()))
+	}
+
+	response, err := impl.Client.MyListActionTasks(owner, repo)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list action tasks: %w", err)
+	}
+
+	if response.TotalCount == 0 || len(response.WorkflowRuns) == 0 {
+		return textResult("No action tasks found in this repository."), nil, nil
+	}
+
+	taskList := types.ActionTaskList{MyActionTaskResponse: response}
+	return textResult(fmt.Sprintf("Found %d action tasks\n\n%s", response.TotalCount, taskList.ToMarkdown())), nil, nil
+}
+
+func (impl ListImpl) listIssueDependencies(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionList, "issue_dependency", err.Error()))
+	}
+
+	index, ok := args["index"].(float64)
+	if !ok || index <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionList, "issue_dependency", "index is required"))
+	}
+
+	issues, err := impl.Client.MyListIssueDependencies(owner, repo, int64(index))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list dependencies: %w", err)
+	}
+
+	deps := types.IssueDependencyList(issues)
+	return textResult(fmt.Sprintf("## Issues that block #%d\n\n%s", int(index), deps.ToMarkdown())), nil, nil
+}
+
+func (impl ListImpl) listIssueBlocking(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionList, "issue_blocking", err.Error()))
+	}
+
+	index, ok := args["index"].(float64)
+	if !ok || index <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionList, "issue_blocking", "index is required"))
+	}
+
+	issues, err := impl.Client.MyListIssueBlocking(owner, repo, int64(index))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list blocking issues: %w", err)
+	}
+
+	blocking := types.IssueBlockingList(issues)
+	return textResult(fmt.Sprintf("## Issues blocked by #%d\n\n%s", int(index), blocking.ToMarkdown())), nil, nil
+}

--- a/tools/unified/manual.go
+++ b/tools/unified/manual.go
@@ -1,0 +1,192 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright © 2025 Ronmi Ren <ronmi.ren@gmail.com>
+
+package unified
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/raohwork/forgejo-mcp/tools"
+)
+
+// ManualParams defines the parameters for the gitea_manual tool.
+type ManualParams struct {
+	// Action is the operation type to get documentation for.
+	// If omitted, lists all available actions.
+	Action string `json:"action,omitempty"`
+	// Resource is the resource type to get documentation for.
+	// Required when action is specified (except for link/unlink which use 'type').
+	Resource string `json:"resource,omitempty"`
+	// Type is the link type for link/unlink actions.
+	Type string `json:"type,omitempty"`
+}
+
+// ManualImpl implements the gitea_manual tool for on-demand documentation lookup.
+type ManualImpl struct {
+	Client *tools.Client // Not used but kept for interface consistency
+}
+
+// Definition describes the gitea_manual tool.
+func (ManualImpl) Definition() *mcp.Tool {
+	return &mcp.Tool{
+		Name:  "gitea_manual",
+		Title: "Gitea Documentation",
+		Description: `Look up documentation for Gitea operations.
+Call without arguments to see all available actions.
+Call with just 'action' to see resources for that action.
+Call with 'action' and 'resource' (or 'type' for link/unlink) for full documentation.`,
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:   true,
+			IdempotentHint: true,
+		},
+		InputSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"action": {
+					Type:        "string",
+					Description: "Action to look up: create, get, list, edit, delete, link, unlink",
+					Enum:        []any{"create", "get", "list", "edit", "delete", "link", "unlink"},
+				},
+				"resource": {
+					Type:        "string",
+					Description: "Resource type (for create/get/list/edit/delete actions)",
+				},
+				"type": {
+					Type:        "string",
+					Description: "Link type (for link/unlink actions): issue_label, issue_dependency, issue_blocking",
+					Enum:        []any{"issue_label", "issue_dependency", "issue_blocking"},
+				},
+			},
+		},
+	}
+}
+
+// Handler implements the documentation lookup logic.
+func (impl ManualImpl) Handler() mcp.ToolHandlerFor[ManualParams, any] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, args ManualParams) (*mcp.CallToolResult, any, error) {
+		var content string
+
+		if args.Action == "" {
+			// List all available actions
+			content = formatOverview()
+		} else if args.Action == "link" || args.Action == "unlink" {
+			if args.Type == "" {
+				// List all link types for this action
+				content = formatLinkTypes(Action(args.Action))
+			} else {
+				// Show specific link type documentation
+				entry, ok := LookupManual(Action(args.Action), args.Type)
+				if !ok {
+					return nil, nil, fmt.Errorf("unknown link type '%s' for action '%s'. Valid types: %v",
+						args.Type, args.Action, ListLinkTypes())
+				}
+				content = FormatManualEntry(entry)
+			}
+		} else {
+			if args.Resource == "" {
+				// List all resources for this action
+				content = formatResourcesForAction(Action(args.Action))
+			} else {
+				// Show specific resource documentation
+				entry, ok := LookupManual(Action(args.Action), args.Resource)
+				if !ok {
+					resources := ListResourcesForAction(Action(args.Action))
+					return nil, nil, fmt.Errorf("unknown resource '%s' for action '%s'. Valid resources: %v",
+						args.Resource, args.Action, resources)
+				}
+				content = FormatManualEntry(entry)
+			}
+		}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: content},
+			},
+		}, nil, nil
+	}
+}
+
+// formatOverview returns a summary of all available actions.
+func formatOverview() string {
+	var sb strings.Builder
+	sb.WriteString("# Gitea MCP Tools\n\n")
+	sb.WriteString("This server provides unified tools for Forgejo/Gitea operations.\n\n")
+	sb.WriteString("## Available Actions\n\n")
+	sb.WriteString("| Action | Description |\n")
+	sb.WriteString("|--------|-------------|\n")
+	sb.WriteString("| `create_gitea` | Create resources (issues, labels, milestones, etc.) |\n")
+	sb.WriteString("| `get_gitea` | Get a single resource by ID/name |\n")
+	sb.WriteString("| `list_gitea` | List resources with filtering |\n")
+	sb.WriteString("| `edit_gitea` | Edit existing resources |\n")
+	sb.WriteString("| `delete_gitea` | Delete resources |\n")
+	sb.WriteString("| `link_gitea` | Create relationships (labels to issues, dependencies) |\n")
+	sb.WriteString("| `unlink_gitea` | Remove relationships |\n")
+	sb.WriteString("\n")
+	sb.WriteString("## How to Use\n\n")
+	sb.WriteString("Each tool takes a `resource` parameter (or `type` for link/unlink) to specify what you're operating on.\n\n")
+	sb.WriteString("**Examples:**\n")
+	sb.WriteString("```\n")
+	sb.WriteString("create_gitea(resource=\"issue\", owner=\"org\", repo=\"project\", title=\"Bug\", body=\"...\")\n")
+	sb.WriteString("list_gitea(resource=\"label\", owner=\"org\", repo=\"project\")\n")
+	sb.WriteString("link_gitea(type=\"issue_label\", owner=\"org\", repo=\"project\", index=42, labels=[1,2])\n")
+	sb.WriteString("```\n\n")
+	sb.WriteString("Call `gitea_manual(action=\"create\")` to see resources for a specific action.\n")
+	sb.WriteString("Call `gitea_manual(action=\"create\", resource=\"issue\")` for full documentation.\n")
+
+	return sb.String()
+}
+
+// formatResourcesForAction lists all resources available for a given action.
+func formatResourcesForAction(action Action) string {
+	resources := ListResourcesForAction(action)
+	sort.Strings(resources)
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("# %s_gitea Resources\n\n", action))
+	sb.WriteString("| Resource | Description |\n")
+	sb.WriteString("|----------|-------------|\n")
+
+	for _, res := range resources {
+		entry, _ := LookupManual(action, res)
+		// Truncate description for table
+		desc := entry.Description
+		if len(desc) > 60 {
+			desc = desc[:57] + "..."
+		}
+		sb.WriteString(fmt.Sprintf("| `%s` | %s |\n", res, desc))
+	}
+
+	sb.WriteString(fmt.Sprintf("\nCall `gitea_manual(action=\"%s\", resource=\"<resource>\")` for full documentation.\n", action))
+	return sb.String()
+}
+
+// formatLinkTypes lists all link types for link/unlink actions.
+func formatLinkTypes(action Action) string {
+	types := ListLinkTypes()
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("# %s_gitea Link Types\n\n", action))
+	sb.WriteString("| Type | Description |\n")
+	sb.WriteString("|------|-------------|\n")
+
+	for _, t := range types {
+		entry, _ := LookupManual(action, t)
+		desc := entry.Description
+		if len(desc) > 60 {
+			desc = desc[:57] + "..."
+		}
+		sb.WriteString(fmt.Sprintf("| `%s` | %s |\n", t, desc))
+	}
+
+	sb.WriteString(fmt.Sprintf("\nCall `gitea_manual(action=\"%s\", type=\"<type>\")` for full documentation.\n", action))
+	return sb.String()
+}

--- a/tools/unified/register.go
+++ b/tools/unified/register.go
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright © 2025 Ronmi Ren <ronmi.ren@gmail.com>
+
+package unified
+
+import (
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/raohwork/forgejo-mcp/tools"
+)
+
+// RegisterAll registers all unified tools with the MCP server.
+// This replaces the 47 individual tool registrations with 8 consolidated tools:
+// - gitea_manual: On-demand documentation lookup
+// - create_gitea: Create resources
+// - get_gitea: Get single resources
+// - list_gitea: List resources
+// - edit_gitea: Edit resources
+// - delete_gitea: Delete resources
+// - link_gitea: Create relationships
+// - unlink_gitea: Remove relationships
+func RegisterAll(s *mcp.Server, cl *tools.Client) {
+	tools.Register(s, &ManualImpl{Client: cl})
+	tools.Register(s, &CreateImpl{Client: cl})
+	tools.Register(s, &GetImpl{Client: cl})
+	tools.Register(s, &ListImpl{Client: cl})
+	tools.Register(s, &EditImpl{Client: cl})
+	tools.Register(s, &DeleteImpl{Client: cl})
+	tools.Register(s, &LinkImpl{Client: cl})
+	tools.Register(s, &UnlinkImpl{Client: cl})
+}

--- a/tools/unified/schema.go
+++ b/tools/unified/schema.go
@@ -1,0 +1,666 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright © 2025 Ronmi Ren <ronmi.ren@gmail.com>
+
+package unified
+
+import "fmt"
+
+// Action represents the type of operation being performed.
+type Action string
+
+const (
+	ActionCreate Action = "create"
+	ActionGet    Action = "get"
+	ActionList   Action = "list"
+	ActionEdit   Action = "edit"
+	ActionDelete Action = "delete"
+	ActionLink   Action = "link"
+	ActionUnlink Action = "unlink"
+)
+
+// Resource represents the type of Forgejo resource being operated on.
+type Resource string
+
+const (
+	ResourceIssue             Resource = "issue"
+	ResourceIssueComment      Resource = "issue_comment"
+	ResourceIssueAttachment   Resource = "issue_attachment"
+	ResourceLabel             Resource = "label"
+	ResourceMilestone         Resource = "milestone"
+	ResourceRelease           Resource = "release"
+	ResourceReleaseAttachment Resource = "release_attachment"
+	ResourceWikiPage          Resource = "wiki_page"
+	ResourcePullRequest       Resource = "pull_request"
+	ResourceRepository        Resource = "repository"
+	ResourceActionTask        Resource = "action_task"
+)
+
+// LinkType represents the type of relationship between resources.
+type LinkType string
+
+const (
+	LinkIssueLabel      LinkType = "issue_label"
+	LinkIssueDependency LinkType = "issue_dependency"
+	LinkIssueBlocking   LinkType = "issue_blocking"
+)
+
+// ParamSpec describes a parameter for documentation purposes.
+type ParamSpec struct {
+	Name        string
+	Type        string // "string", "integer", "boolean", "array"
+	Required    bool
+	Description string
+	Enum        []string // Valid values for enum types
+}
+
+// ActionDoc contains documentation for a specific action+resource combination.
+type ActionDoc struct {
+	Description string
+	Params      []ParamSpec
+	Example     string
+}
+
+// ManualEntry is the documentation for a specific action+resource or action+linktype.
+type ManualEntry struct {
+	Action      Action
+	Resource    Resource // For non-link actions
+	LinkType    LinkType // For link/unlink actions
+	Description string
+	Params      []ParamSpec
+	Example     string
+}
+
+// commonRepoParams returns the common owner/repo parameters.
+func commonRepoParams() []ParamSpec {
+	return []ParamSpec{
+		{Name: "owner", Type: "string", Required: true, Description: "Repository owner (username or organization)"},
+		{Name: "repo", Type: "string", Required: true, Description: "Repository name"},
+	}
+}
+
+// Manual is the documentation registry for all action+resource combinations.
+// It provides on-demand documentation lookup and powers rich error messages.
+var Manual = map[string]ManualEntry{
+	// === CREATE ===
+	"create:issue": {
+		Action:      ActionCreate,
+		Resource:    ResourceIssue,
+		Description: "Create a new issue in a repository.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "title", Type: "string", Required: true, Description: "Issue title"},
+			ParamSpec{Name: "body", Type: "string", Required: true, Description: "Issue body (markdown)"},
+			ParamSpec{Name: "assignees", Type: "array", Required: false, Description: "Usernames to assign"},
+			ParamSpec{Name: "milestone", Type: "integer", Required: false, Description: "Milestone ID"},
+			ParamSpec{Name: "labels", Type: "array", Required: false, Description: "Label IDs to attach"},
+			ParamSpec{Name: "due_date", Type: "string", Required: false, Description: "Due date (RFC3339 format)"},
+		),
+		Example: `create_gitea(resource="issue", owner="org", repo="project", title="Bug report", body="Description...")`,
+	},
+	"create:issue_comment": {
+		Action:      ActionCreate,
+		Resource:    ResourceIssueComment,
+		Description: "Add a comment to an issue.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "index", Type: "integer", Required: true, Description: "Issue number"},
+			ParamSpec{Name: "body", Type: "string", Required: true, Description: "Comment body (markdown)"},
+		),
+		Example: `create_gitea(resource="issue_comment", owner="org", repo="project", index=42, body="Thanks!")`,
+	},
+	"create:label": {
+		Action:      ActionCreate,
+		Resource:    ResourceLabel,
+		Description: "Create a new label in a repository.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "name", Type: "string", Required: true, Description: "Label name"},
+			ParamSpec{Name: "color", Type: "string", Required: true, Description: "Hex color (without #, e.g., 'ff0000')"},
+			ParamSpec{Name: "description", Type: "string", Required: false, Description: "Label description"},
+		),
+		Example: `create_gitea(resource="label", owner="org", repo="project", name="bug", color="ff0000")`,
+	},
+	"create:milestone": {
+		Action:      ActionCreate,
+		Resource:    ResourceMilestone,
+		Description: "Create a new milestone in a repository.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "title", Type: "string", Required: true, Description: "Milestone title"},
+			ParamSpec{Name: "description", Type: "string", Required: false, Description: "Milestone description"},
+			ParamSpec{Name: "due_date", Type: "string", Required: false, Description: "Due date (RFC3339 format)"},
+			ParamSpec{Name: "state", Type: "string", Required: false, Description: "State: 'open' or 'closed'", Enum: []string{"open", "closed"}},
+		),
+		Example: `create_gitea(resource="milestone", owner="org", repo="project", title="v1.0")`,
+	},
+	"create:release": {
+		Action:      ActionCreate,
+		Resource:    ResourceRelease,
+		Description: "Create a new release in a repository.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "tag_name", Type: "string", Required: true, Description: "Git tag name"},
+			ParamSpec{Name: "name", Type: "string", Required: true, Description: "Release title"},
+			ParamSpec{Name: "body", Type: "string", Required: false, Description: "Release notes (markdown)"},
+			ParamSpec{Name: "target_commitish", Type: "string", Required: false, Description: "Target branch or commit SHA"},
+			ParamSpec{Name: "draft", Type: "boolean", Required: false, Description: "Is draft release"},
+			ParamSpec{Name: "prerelease", Type: "boolean", Required: false, Description: "Is prerelease"},
+		),
+		Example: `create_gitea(resource="release", owner="org", repo="project", tag_name="v1.0.0", name="Version 1.0")`,
+	},
+	"create:wiki_page": {
+		Action:      ActionCreate,
+		Resource:    ResourceWikiPage,
+		Description: "Create a new wiki page in a repository.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "title", Type: "string", Required: true, Description: "Page title"},
+			ParamSpec{Name: "content", Type: "string", Required: true, Description: "Page content (markdown)"},
+			ParamSpec{Name: "message", Type: "string", Required: false, Description: "Commit message"},
+		),
+		Example: `create_gitea(resource="wiki_page", owner="org", repo="project", title="Home", content="# Welcome")`,
+	},
+	"create:pull_request": {
+		Action:      ActionCreate,
+		Resource:    ResourcePullRequest,
+		Description: "Create a new pull request.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "title", Type: "string", Required: true, Description: "PR title"},
+			ParamSpec{Name: "body", Type: "string", Required: false, Description: "PR description (markdown)"},
+			ParamSpec{Name: "head", Type: "string", Required: true, Description: "Source branch (or 'user:branch' for forks)"},
+			ParamSpec{Name: "base", Type: "string", Required: true, Description: "Target branch"},
+			ParamSpec{Name: "assignees", Type: "array", Required: false, Description: "Usernames to assign"},
+			ParamSpec{Name: "milestone", Type: "integer", Required: false, Description: "Milestone ID"},
+			ParamSpec{Name: "labels", Type: "array", Required: false, Description: "Label IDs"},
+		),
+		Example: `create_gitea(resource="pull_request", owner="org", repo="project", title="Feature X", head="feature-x", base="main")`,
+	},
+
+	// === GET ===
+	"get:issue": {
+		Action:      ActionGet,
+		Resource:    ResourceIssue,
+		Description: "Get details of a specific issue.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "index", Type: "integer", Required: true, Description: "Issue number"},
+		),
+		Example: `get_gitea(resource="issue", owner="org", repo="project", index=42)`,
+	},
+	"get:wiki_page": {
+		Action:      ActionGet,
+		Resource:    ResourceWikiPage,
+		Description: "Get content of a specific wiki page.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "page_name", Type: "string", Required: true, Description: "Wiki page name"},
+		),
+		Example: `get_gitea(resource="wiki_page", owner="org", repo="project", page_name="Home")`,
+	},
+	"get:pull_request": {
+		Action:      ActionGet,
+		Resource:    ResourcePullRequest,
+		Description: "Get details of a specific pull request.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "index", Type: "integer", Required: true, Description: "PR number"},
+		),
+		Example: `get_gitea(resource="pull_request", owner="org", repo="project", index=42)`,
+	},
+	"get:repository": {
+		Action:      ActionGet,
+		Resource:    ResourceRepository,
+		Description: "Get details of a specific repository.",
+		Params: commonRepoParams(),
+		Example: `get_gitea(resource="repository", owner="org", repo="project")`,
+	},
+
+	// === LIST ===
+	"list:issue": {
+		Action:      ActionList,
+		Resource:    ResourceIssue,
+		Description: "List issues in a repository with optional filtering.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "state", Type: "string", Required: false, Description: "Filter by state", Enum: []string{"open", "closed", "all"}},
+			ParamSpec{Name: "labels", Type: "string", Required: false, Description: "Comma-separated label names"},
+			ParamSpec{Name: "milestones", Type: "string", Required: false, Description: "Comma-separated milestone names/IDs"},
+			ParamSpec{Name: "assignees", Type: "string", Required: false, Description: "Comma-separated usernames"},
+			ParamSpec{Name: "q", Type: "string", Required: false, Description: "Search query"},
+			ParamSpec{Name: "sort", Type: "string", Required: false, Description: "Sort field", Enum: []string{"created", "updated", "comments"}},
+			ParamSpec{Name: "order", Type: "string", Required: false, Description: "Sort order", Enum: []string{"asc", "desc"}},
+			ParamSpec{Name: "page", Type: "integer", Required: false, Description: "Page number"},
+			ParamSpec{Name: "limit", Type: "integer", Required: false, Description: "Results per page (max 50)"},
+			ParamSpec{Name: "since", Type: "string", Required: false, Description: "Only issues updated after (RFC3339)"},
+			ParamSpec{Name: "before", Type: "string", Required: false, Description: "Only issues updated before (RFC3339)"},
+		),
+		Example: `list_gitea(resource="issue", owner="org", repo="project", state="open", labels="bug")`,
+	},
+	"list:issue_comment": {
+		Action:      ActionList,
+		Resource:    ResourceIssueComment,
+		Description: "List comments on an issue.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "index", Type: "integer", Required: true, Description: "Issue number"},
+			ParamSpec{Name: "since", Type: "string", Required: false, Description: "Only comments after (RFC3339)"},
+			ParamSpec{Name: "before", Type: "string", Required: false, Description: "Only comments before (RFC3339)"},
+		),
+		Example: `list_gitea(resource="issue_comment", owner="org", repo="project", index=42)`,
+	},
+	"list:issue_attachment": {
+		Action:      ActionList,
+		Resource:    ResourceIssueAttachment,
+		Description: "List attachments on an issue.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "index", Type: "integer", Required: true, Description: "Issue number"},
+		),
+		Example: `list_gitea(resource="issue_attachment", owner="org", repo="project", index=42)`,
+	},
+	"list:label": {
+		Action:      ActionList,
+		Resource:    ResourceLabel,
+		Description: "List all labels in a repository.",
+		Params:      commonRepoParams(),
+		Example:     `list_gitea(resource="label", owner="org", repo="project")`,
+	},
+	"list:milestone": {
+		Action:      ActionList,
+		Resource:    ResourceMilestone,
+		Description: "List milestones in a repository.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "state", Type: "string", Required: false, Description: "Filter by state", Enum: []string{"open", "closed", "all"}},
+			ParamSpec{Name: "name", Type: "string", Required: false, Description: "Filter by name"},
+			ParamSpec{Name: "page", Type: "integer", Required: false, Description: "Page number"},
+			ParamSpec{Name: "limit", Type: "integer", Required: false, Description: "Results per page"},
+		),
+		Example: `list_gitea(resource="milestone", owner="org", repo="project", state="open")`,
+	},
+	"list:release": {
+		Action:      ActionList,
+		Resource:    ResourceRelease,
+		Description: "List releases in a repository.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "page", Type: "integer", Required: false, Description: "Page number"},
+			ParamSpec{Name: "limit", Type: "integer", Required: false, Description: "Results per page"},
+		),
+		Example: `list_gitea(resource="release", owner="org", repo="project")`,
+	},
+	"list:release_attachment": {
+		Action:      ActionList,
+		Resource:    ResourceReleaseAttachment,
+		Description: "List attachments on a release.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "id", Type: "integer", Required: true, Description: "Release ID"},
+		),
+		Example: `list_gitea(resource="release_attachment", owner="org", repo="project", id=1)`,
+	},
+	"list:wiki_page": {
+		Action:      ActionList,
+		Resource:    ResourceWikiPage,
+		Description: "List all wiki pages in a repository.",
+		Params:      commonRepoParams(),
+		Example:     `list_gitea(resource="wiki_page", owner="org", repo="project")`,
+	},
+	"list:pull_request": {
+		Action:      ActionList,
+		Resource:    ResourcePullRequest,
+		Description: "List pull requests in a repository.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "state", Type: "string", Required: false, Description: "Filter by state", Enum: []string{"open", "closed", "all"}},
+			ParamSpec{Name: "sort", Type: "string", Required: false, Description: "Sort field", Enum: []string{"oldest", "recentupdate", "leastupdate", "mostcomment", "leastcomment", "priority"}},
+			ParamSpec{Name: "milestone", Type: "integer", Required: false, Description: "Milestone ID"},
+			ParamSpec{Name: "labels", Type: "array", Required: false, Description: "Label IDs"},
+			ParamSpec{Name: "page", Type: "integer", Required: false, Description: "Page number"},
+			ParamSpec{Name: "limit", Type: "integer", Required: false, Description: "Results per page"},
+		),
+		Example: `list_gitea(resource="pull_request", owner="org", repo="project", state="open")`,
+	},
+	"list:repository": {
+		Action:      ActionList,
+		Resource:    ResourceRepository,
+		Description: "List repositories. Use 'scope' to choose: 'my' (authenticated user), 'org' (organization), or 'search' (search all).",
+		Params: []ParamSpec{
+			{Name: "scope", Type: "string", Required: true, Description: "Listing scope", Enum: []string{"my", "org", "search"}},
+			{Name: "org", Type: "string", Required: false, Description: "Organization name (required for scope='org')"},
+			{Name: "q", Type: "string", Required: false, Description: "Search query (for scope='search')"},
+			{Name: "topic", Type: "boolean", Required: false, Description: "Search in topics (for scope='search')"},
+			{Name: "include_desc", Type: "boolean", Required: false, Description: "Search in description (for scope='search')"},
+			{Name: "template", Type: "boolean", Required: false, Description: "Only templates (for scope='search')"},
+			{Name: "archived", Type: "boolean", Required: false, Description: "Only archived (for scope='search')"},
+			{Name: "private", Type: "boolean", Required: false, Description: "Only private (for scope='search')"},
+			{Name: "page", Type: "integer", Required: false, Description: "Page number"},
+			{Name: "limit", Type: "integer", Required: false, Description: "Results per page"},
+		},
+		Example: `list_gitea(resource="repository", scope="my")`,
+	},
+	"list:action_task": {
+		Action:      ActionList,
+		Resource:    ResourceActionTask,
+		Description: "List Forgejo Actions tasks (CI/CD runs).",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "page", Type: "integer", Required: false, Description: "Page number"},
+			ParamSpec{Name: "limit", Type: "integer", Required: false, Description: "Results per page"},
+		),
+		Example: `list_gitea(resource="action_task", owner="org", repo="project")`,
+	},
+	"list:issue_dependency": {
+		Action:      ActionList,
+		Resource:    Resource("issue_dependency"),
+		Description: "List issues that block this issue (dependencies).",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "index", Type: "integer", Required: true, Description: "Issue number"},
+		),
+		Example: `list_gitea(resource="issue_dependency", owner="org", repo="project", index=42)`,
+	},
+	"list:issue_blocking": {
+		Action:      ActionList,
+		Resource:    Resource("issue_blocking"),
+		Description: "List issues that are blocked by this issue.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "index", Type: "integer", Required: true, Description: "Issue number"},
+		),
+		Example: `list_gitea(resource="issue_blocking", owner="org", repo="project", index=42)`,
+	},
+
+	// === EDIT ===
+	"edit:issue": {
+		Action:      ActionEdit,
+		Resource:    ResourceIssue,
+		Description: "Edit an existing issue.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "index", Type: "integer", Required: true, Description: "Issue number"},
+			ParamSpec{Name: "title", Type: "string", Required: false, Description: "New title"},
+			ParamSpec{Name: "body", Type: "string", Required: false, Description: "New body"},
+			ParamSpec{Name: "state", Type: "string", Required: false, Description: "New state", Enum: []string{"open", "closed"}},
+			ParamSpec{Name: "assignees", Type: "array", Required: false, Description: "New assignees"},
+			ParamSpec{Name: "milestone", Type: "integer", Required: false, Description: "New milestone ID"},
+			ParamSpec{Name: "due_date", Type: "string", Required: false, Description: "New due date (RFC3339)"},
+		),
+		Example: `edit_gitea(resource="issue", owner="org", repo="project", index=42, state="closed")`,
+	},
+	"edit:issue_comment": {
+		Action:      ActionEdit,
+		Resource:    ResourceIssueComment,
+		Description: "Edit an issue comment.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "id", Type: "integer", Required: true, Description: "Comment ID"},
+			ParamSpec{Name: "body", Type: "string", Required: true, Description: "New comment body"},
+		),
+		Example: `edit_gitea(resource="issue_comment", owner="org", repo="project", id=123, body="Updated comment")`,
+	},
+	"edit:issue_attachment": {
+		Action:      ActionEdit,
+		Resource:    ResourceIssueAttachment,
+		Description: "Edit an issue attachment's name.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "index", Type: "integer", Required: true, Description: "Issue number"},
+			ParamSpec{Name: "attachment_id", Type: "integer", Required: true, Description: "Attachment ID"},
+			ParamSpec{Name: "name", Type: "string", Required: true, Description: "New filename"},
+		),
+		Example: `edit_gitea(resource="issue_attachment", owner="org", repo="project", index=42, attachment_id=1, name="new_name.png")`,
+	},
+	"edit:label": {
+		Action:      ActionEdit,
+		Resource:    ResourceLabel,
+		Description: "Edit a label.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "id", Type: "integer", Required: true, Description: "Label ID"},
+			ParamSpec{Name: "name", Type: "string", Required: false, Description: "New name"},
+			ParamSpec{Name: "color", Type: "string", Required: false, Description: "New color (hex without #)"},
+			ParamSpec{Name: "description", Type: "string", Required: false, Description: "New description"},
+		),
+		Example: `edit_gitea(resource="label", owner="org", repo="project", id=1, color="00ff00")`,
+	},
+	"edit:milestone": {
+		Action:      ActionEdit,
+		Resource:    ResourceMilestone,
+		Description: "Edit a milestone.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "id", Type: "integer", Required: true, Description: "Milestone ID"},
+			ParamSpec{Name: "title", Type: "string", Required: false, Description: "New title"},
+			ParamSpec{Name: "description", Type: "string", Required: false, Description: "New description"},
+			ParamSpec{Name: "due_date", Type: "string", Required: false, Description: "New due date (RFC3339)"},
+			ParamSpec{Name: "state", Type: "string", Required: false, Description: "New state", Enum: []string{"open", "closed"}},
+		),
+		Example: `edit_gitea(resource="milestone", owner="org", repo="project", id=1, state="closed")`,
+	},
+	"edit:release": {
+		Action:      ActionEdit,
+		Resource:    ResourceRelease,
+		Description: "Edit a release.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "id", Type: "integer", Required: true, Description: "Release ID"},
+			ParamSpec{Name: "tag_name", Type: "string", Required: false, Description: "New tag name"},
+			ParamSpec{Name: "name", Type: "string", Required: false, Description: "New title"},
+			ParamSpec{Name: "body", Type: "string", Required: false, Description: "New release notes"},
+			ParamSpec{Name: "target_commitish", Type: "string", Required: false, Description: "New target"},
+			ParamSpec{Name: "draft", Type: "boolean", Required: false, Description: "Is draft"},
+			ParamSpec{Name: "prerelease", Type: "boolean", Required: false, Description: "Is prerelease"},
+		),
+		Example: `edit_gitea(resource="release", owner="org", repo="project", id=1, prerelease=false)`,
+	},
+	"edit:release_attachment": {
+		Action:      ActionEdit,
+		Resource:    ResourceReleaseAttachment,
+		Description: "Edit a release attachment's name.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "id", Type: "integer", Required: true, Description: "Release ID"},
+			ParamSpec{Name: "attachment_id", Type: "integer", Required: true, Description: "Attachment ID"},
+			ParamSpec{Name: "name", Type: "string", Required: true, Description: "New filename"},
+		),
+		Example: `edit_gitea(resource="release_attachment", owner="org", repo="project", id=1, attachment_id=2, name="app-v1.0.zip")`,
+	},
+	"edit:wiki_page": {
+		Action:      ActionEdit,
+		Resource:    ResourceWikiPage,
+		Description: "Edit a wiki page.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "page_name", Type: "string", Required: true, Description: "Current page name"},
+			ParamSpec{Name: "title", Type: "string", Required: false, Description: "New title"},
+			ParamSpec{Name: "content", Type: "string", Required: true, Description: "New content"},
+			ParamSpec{Name: "message", Type: "string", Required: false, Description: "Commit message"},
+		),
+		Example: `edit_gitea(resource="wiki_page", owner="org", repo="project", page_name="Home", content="# Updated")`,
+	},
+
+	// === DELETE ===
+	"delete:issue_comment": {
+		Action:      ActionDelete,
+		Resource:    ResourceIssueComment,
+		Description: "Delete an issue comment.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "id", Type: "integer", Required: true, Description: "Comment ID"},
+		),
+		Example: `delete_gitea(resource="issue_comment", owner="org", repo="project", id=123)`,
+	},
+	"delete:issue_attachment": {
+		Action:      ActionDelete,
+		Resource:    ResourceIssueAttachment,
+		Description: "Delete an issue attachment.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "index", Type: "integer", Required: true, Description: "Issue number"},
+			ParamSpec{Name: "attachment_id", Type: "integer", Required: true, Description: "Attachment ID"},
+		),
+		Example: `delete_gitea(resource="issue_attachment", owner="org", repo="project", index=42, attachment_id=1)`,
+	},
+	"delete:label": {
+		Action:      ActionDelete,
+		Resource:    ResourceLabel,
+		Description: "Delete a label from a repository.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "id", Type: "integer", Required: true, Description: "Label ID"},
+		),
+		Example: `delete_gitea(resource="label", owner="org", repo="project", id=1)`,
+	},
+	"delete:milestone": {
+		Action:      ActionDelete,
+		Resource:    ResourceMilestone,
+		Description: "Delete a milestone.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "id", Type: "integer", Required: true, Description: "Milestone ID"},
+		),
+		Example: `delete_gitea(resource="milestone", owner="org", repo="project", id=1)`,
+	},
+	"delete:release": {
+		Action:      ActionDelete,
+		Resource:    ResourceRelease,
+		Description: "Delete a release.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "id", Type: "integer", Required: true, Description: "Release ID"},
+		),
+		Example: `delete_gitea(resource="release", owner="org", repo="project", id=1)`,
+	},
+	"delete:release_attachment": {
+		Action:      ActionDelete,
+		Resource:    ResourceReleaseAttachment,
+		Description: "Delete a release attachment.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "id", Type: "integer", Required: true, Description: "Release ID"},
+			ParamSpec{Name: "attachment_id", Type: "integer", Required: true, Description: "Attachment ID"},
+		),
+		Example: `delete_gitea(resource="release_attachment", owner="org", repo="project", id=1, attachment_id=2)`,
+	},
+	"delete:wiki_page": {
+		Action:      ActionDelete,
+		Resource:    ResourceWikiPage,
+		Description: "Delete a wiki page.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "page_name", Type: "string", Required: true, Description: "Page name to delete"},
+		),
+		Example: `delete_gitea(resource="wiki_page", owner="org", repo="project", page_name="OldPage")`,
+	},
+
+	// === LINK ===
+	"link:issue_label": {
+		Action:      ActionLink,
+		LinkType:    LinkIssueLabel,
+		Description: "Add labels to an issue.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "index", Type: "integer", Required: true, Description: "Issue number"},
+			ParamSpec{Name: "labels", Type: "array", Required: true, Description: "Label IDs to add"},
+		),
+		Example: `link_gitea(type="issue_label", owner="org", repo="project", index=42, labels=[1, 2])`,
+	},
+	"link:issue_dependency": {
+		Action:      ActionLink,
+		LinkType:    LinkIssueDependency,
+		Description: "Add a dependency: issue cannot be closed until dependency_index is closed.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "index", Type: "integer", Required: true, Description: "Dependent issue number"},
+			ParamSpec{Name: "dependency_index", Type: "integer", Required: true, Description: "Issue that blocks this one"},
+		),
+		Example: `link_gitea(type="issue_dependency", owner="org", repo="project", index=42, dependency_index=10)`,
+	},
+	"link:issue_blocking": {
+		Action:      ActionLink,
+		LinkType:    LinkIssueBlocking,
+		Description: "Add a blocking relationship: blocked_index cannot be closed until index is closed.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "index", Type: "integer", Required: true, Description: "Blocking issue number"},
+			ParamSpec{Name: "blocked_index", Type: "integer", Required: true, Description: "Issue that will be blocked"},
+		),
+		Example: `link_gitea(type="issue_blocking", owner="org", repo="project", index=42, blocked_index=50)`,
+	},
+
+	// === UNLINK ===
+	"unlink:issue_label": {
+		Action:      ActionUnlink,
+		LinkType:    LinkIssueLabel,
+		Description: "Remove a label from an issue.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "index", Type: "integer", Required: true, Description: "Issue number"},
+			ParamSpec{Name: "label_id", Type: "integer", Required: true, Description: "Label ID to remove"},
+		),
+		Example: `unlink_gitea(type="issue_label", owner="org", repo="project", index=42, label_id=1)`,
+	},
+	"unlink:issue_dependency": {
+		Action:      ActionUnlink,
+		LinkType:    LinkIssueDependency,
+		Description: "Remove a dependency relationship.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "index", Type: "integer", Required: true, Description: "Dependent issue number"},
+			ParamSpec{Name: "dependency_index", Type: "integer", Required: true, Description: "Dependency to remove"},
+		),
+		Example: `unlink_gitea(type="issue_dependency", owner="org", repo="project", index=42, dependency_index=10)`,
+	},
+	"unlink:issue_blocking": {
+		Action:      ActionUnlink,
+		LinkType:    LinkIssueBlocking,
+		Description: "Remove a blocking relationship.",
+		Params: append(commonRepoParams(),
+			ParamSpec{Name: "index", Type: "integer", Required: true, Description: "Blocking issue number"},
+			ParamSpec{Name: "blocked_index", Type: "integer", Required: true, Description: "Issue to unblock"},
+		),
+		Example: `unlink_gitea(type="issue_blocking", owner="org", repo="project", index=42, blocked_index=50)`,
+	},
+}
+
+// LookupManual retrieves documentation for an action+resource or action+linktype combination.
+func LookupManual(action Action, resourceOrType string) (ManualEntry, bool) {
+	key := fmt.Sprintf("%s:%s", action, resourceOrType)
+	entry, ok := Manual[key]
+	return entry, ok
+}
+
+// FormatManualEntry renders a ManualEntry as human-readable documentation.
+func FormatManualEntry(entry ManualEntry) string {
+	var result string
+
+	// Header
+	if entry.Resource != "" {
+		result = fmt.Sprintf("## %s %s\n\n", entry.Action, entry.Resource)
+	} else {
+		result = fmt.Sprintf("## %s %s\n\n", entry.Action, entry.LinkType)
+	}
+
+	// Description
+	result += entry.Description + "\n\n"
+
+	// Parameters
+	result += "### Parameters\n\n"
+	result += "| Name | Type | Required | Description |\n"
+	result += "|------|------|----------|-------------|\n"
+	for _, p := range entry.Params {
+		req := "no"
+		if p.Required {
+			req = "yes"
+		}
+		desc := p.Description
+		if len(p.Enum) > 0 {
+			desc += fmt.Sprintf(" (values: %v)", p.Enum)
+		}
+		result += fmt.Sprintf("| %s | %s | %s | %s |\n", p.Name, p.Type, req, desc)
+	}
+
+	// Example
+	result += fmt.Sprintf("\n### Example\n\n```\n%s\n```\n", entry.Example)
+
+	return result
+}
+
+// FormatValidationError creates a helpful error message with the relevant schema.
+func FormatValidationError(action Action, resourceOrType, message string) string {
+	entry, ok := LookupManual(action, resourceOrType)
+	if !ok {
+		return fmt.Sprintf("Error: %s\n\nNo documentation found for %s:%s", message, action, resourceOrType)
+	}
+
+	result := fmt.Sprintf("Error: %s\n\n", message)
+	result += "Here's how to use this operation:\n\n"
+	result += FormatManualEntry(entry)
+	return result
+}
+
+// ListResourcesForAction returns all valid resources for a given action.
+func ListResourcesForAction(action Action) []string {
+	var resources []string
+	prefix := fmt.Sprintf("%s:", action)
+	for key := range Manual {
+		if len(key) > len(prefix) && key[:len(prefix)] == prefix {
+			resources = append(resources, key[len(prefix):])
+		}
+	}
+	return resources
+}
+
+// ListLinkTypes returns all valid link types.
+func ListLinkTypes() []string {
+	return []string{
+		string(LinkIssueLabel),
+		string(LinkIssueDependency),
+		string(LinkIssueBlocking),
+	}
+}

--- a/tools/unified/unlink.go
+++ b/tools/unified/unlink.go
@@ -1,0 +1,170 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright © 2025 Ronmi Ren <ronmi.ren@gmail.com>
+
+package unified
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/raohwork/forgejo-mcp/tools"
+	"github.com/raohwork/forgejo-mcp/types"
+)
+
+// UnlinkImpl implements the unlink_gitea tool.
+type UnlinkImpl struct {
+	Client *tools.Client
+}
+
+// Definition describes the unlink_gitea tool with minimal schema.
+func (UnlinkImpl) Definition() *mcp.Tool {
+	return &mcp.Tool{
+		Name:  "unlink_gitea",
+		Title: "Unlink Gitea Resources",
+		Description: `Remove relationships between resources in Forgejo/Gitea.
+Types: issue_label (remove label from issue), issue_dependency (remove dependency), issue_blocking (remove blocking).
+Use gitea_manual(action="unlink") for details.`,
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:    false,
+			DestructiveHint: tools.BoolPtr(true),
+			IdempotentHint:  true,
+		},
+		InputSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"type": {
+					Type:        "string",
+					Description: "Link type to remove",
+					Enum:        []any{"issue_label", "issue_dependency", "issue_blocking"},
+				},
+				"owner": {
+					Type:        "string",
+					Description: "Repository owner",
+				},
+				"repo": {
+					Type:        "string",
+					Description: "Repository name",
+				},
+			},
+			Required:             []string{"type", "owner", "repo"},
+			AdditionalProperties: &jsonschema.Schema{},
+		},
+	}
+}
+
+// Handler dispatches to the appropriate unlink logic based on type.
+func (impl UnlinkImpl) Handler() mcp.ToolHandlerFor[map[string]any, any] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+		linkType, _ := args["type"].(string)
+		if linkType == "" {
+			return nil, nil, fmt.Errorf("type is required. Valid types: %v", ListLinkTypes())
+		}
+
+		if _, ok := LookupManual(ActionUnlink, linkType); !ok {
+			return nil, nil, fmt.Errorf("unknown type '%s'. Valid types: %v", linkType, ListLinkTypes())
+		}
+
+		switch linkType {
+		case "issue_label":
+			return impl.removeIssueLabel(args)
+		case "issue_dependency":
+			return impl.removeIssueDependency(args)
+		case "issue_blocking":
+			return impl.removeIssueBlocking(args)
+		default:
+			return nil, nil, fmt.Errorf(FormatValidationError(ActionUnlink, linkType, "not implemented"))
+		}
+	}
+}
+
+func (impl UnlinkImpl) removeIssueLabel(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionUnlink, "issue_label", err.Error()))
+	}
+
+	index, ok := args["index"].(float64)
+	if !ok || index <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionUnlink, "issue_label", "index is required"))
+	}
+
+	labelID, ok := args["label_id"].(float64)
+	if !ok || labelID <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionUnlink, "issue_label", "label_id is required"))
+	}
+
+	_, err = impl.Client.DeleteIssueLabel(owner, repo, int64(index), int64(labelID))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to remove label: %w", err)
+	}
+
+	return textResult(fmt.Sprintf("Label %d removed from issue #%d", int(labelID), int(index))), nil, nil
+}
+
+func (impl UnlinkImpl) removeIssueDependency(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionUnlink, "issue_dependency", err.Error()))
+	}
+
+	index, ok := args["index"].(float64)
+	if !ok || index <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionUnlink, "issue_dependency", "index is required"))
+	}
+
+	dependencyIndex, ok := args["dependency_index"].(float64)
+	if !ok || dependencyIndex <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionUnlink, "issue_dependency", "dependency_index is required"))
+	}
+
+	dependency := types.MyIssueMeta{
+		Owner: owner,
+		Name:  repo,
+		Index: int64(dependencyIndex),
+	}
+
+	_, err = impl.Client.MyRemoveIssueDependency(owner, repo, int64(index), dependency)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to remove dependency: %w", err)
+	}
+
+	return textResult(fmt.Sprintf("Issue #%d no longer depends on issue #%d",
+		int(index), int(dependencyIndex))), nil, nil
+}
+
+func (impl UnlinkImpl) removeIssueBlocking(args map[string]any) (*mcp.CallToolResult, any, error) {
+	owner, repo, err := extractOwnerRepo(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionUnlink, "issue_blocking", err.Error()))
+	}
+
+	index, ok := args["index"].(float64)
+	if !ok || index <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionUnlink, "issue_blocking", "index is required"))
+	}
+
+	blockedIndex, ok := args["blocked_index"].(float64)
+	if !ok || blockedIndex <= 0 {
+		return nil, nil, fmt.Errorf(FormatValidationError(ActionUnlink, "issue_blocking", "blocked_index is required"))
+	}
+
+	blocked := types.MyIssueMeta{
+		Owner: owner,
+		Name:  repo,
+		Index: int64(blockedIndex),
+	}
+
+	_, err = impl.Client.MyRemoveIssueBlocking(owner, repo, int64(index), blocked)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to remove blocking relationship: %w", err)
+	}
+
+	return textResult(fmt.Sprintf("Issue #%d no longer blocks issue #%d",
+		int(index), int(blockedIndex))), nil, nil
+}


### PR DESCRIPTION
I noticed that this MCP server took up ~16% of context every single conversation, even though I mostly only used it to read/write issues. I used almost every action occasionally, but EVERY session was losing thousands of tokens to tools I wouldn't use.

I wrote this refactor to provide a "user manual" tool so that the LLM can read detailed instructions for whichever specific task it's trying to do, and each task supports multiple target objects. I reduced the amount of explanation in the tools' description because LLMs being used to develop software already understand what issues, repositories, and wiki pages are. Lastly, the error messages are designed to give specific, actionable, token-cheap responses that guide the LLM towards making a correct tool call on the second attempt.

Reduces MCP tool token consumption by 82% (32.7k → 5.7k tokens).

New unified tools:
- gitea_manual: On-demand documentation lookup (lazy-loaded)
- create_gitea: Create resources (issue, label, milestone, etc.)
- get_gitea: Get single resource details
- list_gitea: List resources with filtering
- edit_gitea: Edit existing resources
- delete_gitea: Delete resources
- link_gitea: Create relationships (labels, dependencies)
- unlink_gitea: Remove relationships

Key design decisions:
- Action-based organization leverages LLM implicit knowledge
- Lazy documentation via gitea_manual avoids upfront token cost
- Rich error messages include relevant schema for self-correction

🤖 Generated with [Claude Code](https://claude.com/claude-code)