### PR TITLE
fix: strip "token " prefix in multi-user mode

### DIFF
--- a/cmd/http.go
+++ b/cmd/http.go
@@ -77,6 +77,8 @@ Example:
 			if myToken != "" {
 				if strings.HasPrefix(myToken, "Bearer ") {
 					myToken = myToken[7:]
+				} else if strings.HasPrefix(myToken, "token ") {
+					myToken = myToken[6:]
 				}
 				c, err := tools.NewClient(base, myToken, "", nil)
 				if err == nil {


### PR DESCRIPTION
## Summary

- In multi-user mode (no `--token` flag), the server reads the `Authorization` header from each client request
- The `Bearer ` prefix is correctly stripped, but the `token ` prefix (which is what Forgejo's API docs recommend: `Authorization: token <value>`) is not
- This causes the raw string `token abc123` to be passed to `NewClient`, which then sets `Authorization: token token abc123` — double prefix, silent auth failure
- Adds `token ` prefix stripping alongside the existing `Bearer ` handling

## Test plan

- [ ] Start server in multi-user mode (`forgejo-mcp http --server <url> --address :8080`)
- [ ] Send request with `Authorization: token <valid-token>` header
- [ ] Verify API calls succeed (e.g. `list_my_repositories`)
- [ ] Verify `Authorization: Bearer <token>` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)