### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,3 +209,8 @@ This project is licensed under the [Mozilla Public License 2.0](LICENSE).
 ---
 
 **Start making AI your code repository management partner!** 🚀
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/raohwork-forgejo-mcp).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/raohwork-forgejo-mcp).