### PR TITLE
feat: Add pull request review tools to MCP

### DIFF
--- a/cmd/lib.go
+++ b/cmd/lib.go
@@ -82,6 +82,11 @@ func registerCommands(s *mcp.Server, cl *tools.Client) {
 	tools.Register(s, &pullreq.GetPullRequestImpl{Client: cl})
 	tools.Register(s, &pullreq.CreatePullRequestImpl{Client: cl})
 
+	// Pull request review tools
+	tools.Register(s, &pullreq.ListPullRequestReviewsImpl{Client: cl})
+	tools.Register(s, &pullreq.ListPullRequestReviewCommentsImpl{Client: cl})
+	tools.Register(s, &pullreq.CreatePullRequestReviewImpl{Client: cl})
+
 	// Repository tools
 	tools.Register(s, &repo.SearchRepositoriesImpl{Client: cl})
 	tools.Register(s, &repo.ListMyRepositoriesImpl{Client: cl})

--- a/tools/client_pullreq.go
+++ b/tools/client_pullreq.go
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright © 2025 Ronmi Ren <ronmi.ren@gmail.com>
+
+package tools
+
+import (
+	"fmt"
+
+	"codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v2"
+)
+
+// MyCreatePullReviewCommentOptions is the payload for adding a comment to an
+// existing pull request review. The Forgejo SDK does not expose this endpoint,
+// so it is implemented here against the REST API directly.
+type MyCreatePullReviewCommentOptions struct {
+	Body        string `json:"body"`
+	Path        string `json:"path"`
+	NewPosition int64  `json:"new_position,omitempty"`
+	OldPosition int64  `json:"old_position,omitempty"`
+}
+
+// MyCreatePullReviewComment adds a new inline comment to an existing pull
+// request review, which is how Forgejo continues an inline conversation
+// thread at a given file and line.
+// POST /repos/{owner}/{repo}/pulls/{index}/reviews/{id}/comments
+func (c *Client) MyCreatePullReviewComment(owner, repo string, index, reviewID int64, opt MyCreatePullReviewCommentOptions) (*forgejo.PullReviewComment, error) {
+	endpoint := fmt.Sprintf("/api/v1/repos/%s/%s/pulls/%d/reviews/%d/comments", owner, repo, index, reviewID)
+
+	var result forgejo.PullReviewComment
+	if err := c.sendSimpleRequest("POST", endpoint, opt, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/tools/pullreq/review_comments.go
+++ b/tools/pullreq/review_comments.go
@@ -1,0 +1,102 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright © 2025 Ronmi Ren <ronmi.ren@gmail.com>
+
+package pullreq
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/raohwork/forgejo-mcp/tools"
+	"github.com/raohwork/forgejo-mcp/types"
+)
+
+// ListPullRequestReviewCommentsParams defines the parameters for the
+// list_pull_request_review_comments tool.
+type ListPullRequestReviewCommentsParams struct {
+	// Owner is the username or organization name that owns the repository.
+	Owner string `json:"owner"`
+	// Repo is the name of the repository.
+	Repo string `json:"repo"`
+	// Index is the pull request number.
+	Index int `json:"index"`
+	// ReviewID is the ID of the review whose inline comments should be listed.
+	ReviewID int `json:"review_id"`
+}
+
+// ListPullRequestReviewCommentsImpl implements the read-only MCP tool for listing
+// inline comments belonging to a specific pull request review. Each comment
+// includes the file path, line number, surrounding diff hunk, author, and body.
+type ListPullRequestReviewCommentsImpl struct {
+	Client *tools.Client
+}
+
+func (ListPullRequestReviewCommentsImpl) Definition() *mcp.Tool {
+	return &mcp.Tool{
+		Name:        "list_pull_request_review_comments",
+		Title:       "List Pull Request Review Comments",
+		Description: "List inline review comments for a specific review on a pull request. Each comment includes the file path, line number, diff hunk for context, author, and body.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:   true,
+			IdempotentHint: true,
+		},
+		InputSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"owner": {
+					Type:        "string",
+					Description: "Repository owner (username or organization name)",
+				},
+				"repo": {
+					Type:        "string",
+					Description: "Repository name",
+				},
+				"index": {
+					Type:        "integer",
+					Description: "Pull request index number",
+				},
+				"review_id": {
+					Type:        "integer",
+					Description: "Review ID (from list_pull_request_reviews) whose inline comments to fetch",
+				},
+			},
+			Required: []string{"owner", "repo", "index", "review_id"},
+		},
+	}
+}
+
+func (impl ListPullRequestReviewCommentsImpl) Handler() mcp.ToolHandlerFor[ListPullRequestReviewCommentsParams, any] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, args ListPullRequestReviewCommentsParams) (*mcp.CallToolResult, any, error) {
+		p := args
+
+		comments, _, err := impl.Client.ListPullReviewComments(p.Owner, p.Repo, int64(p.Index), int64(p.ReviewID))
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to list review comments: %w", err)
+		}
+
+		var content string
+		if len(comments) == 0 {
+			content = "No inline comments found for this review."
+		} else {
+			list := make(types.PullReviewCommentList, len(comments))
+			for i, c := range comments {
+				list[i] = &types.PullReviewComment{PullReviewComment: c}
+			}
+			content = fmt.Sprintf("Found %d inline comments\n\n%s", len(comments), list.ToMarkdown())
+		}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{
+					Text: content,
+				},
+			},
+		}, nil, nil
+	}
+}

--- a/tools/pullreq/review_create.go
+++ b/tools/pullreq/review_create.go
@@ -1,0 +1,172 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright © 2025 Ronmi Ren <ronmi.ren@gmail.com>
+
+package pullreq
+
+import (
+	"context"
+	"fmt"
+
+	"codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v2"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/raohwork/forgejo-mcp/tools"
+	"github.com/raohwork/forgejo-mcp/types"
+)
+
+// CreatePullRequestReviewComment is the per-file inline comment payload accepted
+// by the create_pull_request_review tool. Either NewLine or OldLine must be set
+// to indicate the side of the diff the comment applies to.
+type CreatePullRequestReviewComment struct {
+	// Path is the file path within the repository (relative to the repo root).
+	Path string `json:"path"`
+	// Body is the markdown body of the inline comment.
+	Body string `json:"body"`
+	// NewLine is the 1-based line number on the new (post-change) side of the diff.
+	NewLine int `json:"new_line,omitempty"`
+	// OldLine is the 1-based line number on the old (pre-change) side of the diff.
+	OldLine int `json:"old_line,omitempty"`
+}
+
+// CreatePullRequestReviewParams defines the parameters for the
+// create_pull_request_review tool.
+type CreatePullRequestReviewParams struct {
+	// Owner is the username or organization name that owns the repository.
+	Owner string `json:"owner"`
+	// Repo is the name of the repository.
+	Repo string `json:"repo"`
+	// Index is the pull request number.
+	Index int `json:"index"`
+	// Event is the review state: APPROVED, REQUEST_CHANGES, COMMENT, or PENDING.
+	Event string `json:"event,omitempty"`
+	// Body is the overall review body (markdown).
+	Body string `json:"body,omitempty"`
+	// CommitID pins the review to a specific commit SHA (optional).
+	CommitID string `json:"commit_id,omitempty"`
+	// Comments is the list of inline comments to include in the review.
+	Comments []CreatePullRequestReviewComment `json:"comments,omitempty"`
+}
+
+// CreatePullRequestReviewImpl implements the MCP tool for submitting a new pull
+// request review, optionally with inline comments. This is how to "reply" to
+// existing inline review comments — Forgejo threads inline replies by posting a
+// new review containing comments at the same path/line.
+type CreatePullRequestReviewImpl struct {
+	Client *tools.Client
+}
+
+func (CreatePullRequestReviewImpl) Definition() *mcp.Tool {
+	return &mcp.Tool{
+		Name:        "create_pull_request_review",
+		Title:       "Create Pull Request Review",
+		Description: "Submit a new review on a pull request, optionally including inline comments at specific file paths and line numbers. Use this to reply to existing inline review comments by posting a new review with comments at the same path and line.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:    false,
+			DestructiveHint: tools.BoolPtr(false),
+			IdempotentHint:  false,
+		},
+		InputSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"owner": {
+					Type:        "string",
+					Description: "Repository owner (username or organization name)",
+				},
+				"repo": {
+					Type:        "string",
+					Description: "Repository name",
+				},
+				"index": {
+					Type:        "integer",
+					Description: "Pull request index number",
+				},
+				"event": {
+					Type:        "string",
+					Description: "Review state (optional, defaults to COMMENT): APPROVED, REQUEST_CHANGES, COMMENT, or PENDING",
+					Enum:        []any{"APPROVED", "REQUEST_CHANGES", "COMMENT", "PENDING"},
+				},
+				"body": {
+					Type:        "string",
+					Description: "Overall review body in markdown (optional, but required when event is not APPROVED and there are no inline comments)",
+				},
+				"commit_id": {
+					Type:        "string",
+					Description: "Commit SHA to pin the review to (optional)",
+				},
+				"comments": {
+					Type:        "array",
+					Description: "Inline comments to include in the review (optional)",
+					Items: &jsonschema.Schema{
+						Type: "object",
+						Properties: map[string]*jsonschema.Schema{
+							"path": {
+								Type:        "string",
+								Description: "File path relative to the repository root",
+							},
+							"body": {
+								Type:        "string",
+								Description: "Inline comment body (markdown supported)",
+							},
+							"new_line": {
+								Type:        "integer",
+								Description: "1-based line number on the new (post-change) side of the diff. Set this OR old_line.",
+								Minimum:     tools.Float64Ptr(1),
+							},
+							"old_line": {
+								Type:        "integer",
+								Description: "1-based line number on the old (pre-change) side of the diff. Set this OR new_line.",
+								Minimum:     tools.Float64Ptr(1),
+							},
+						},
+						Required: []string{"path", "body"},
+					},
+				},
+			},
+			Required: []string{"owner", "repo", "index"},
+		},
+	}
+}
+
+func (impl CreatePullRequestReviewImpl) Handler() mcp.ToolHandlerFor[CreatePullRequestReviewParams, any] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, args CreatePullRequestReviewParams) (*mcp.CallToolResult, any, error) {
+		p := args
+
+		opt := forgejo.CreatePullReviewOptions{
+			Body:     p.Body,
+			CommitID: p.CommitID,
+		}
+		if p.Event != "" {
+			opt.State = forgejo.ReviewStateType(p.Event)
+		}
+		if len(p.Comments) > 0 {
+			opt.Comments = make([]forgejo.CreatePullReviewComment, len(p.Comments))
+			for i, c := range p.Comments {
+				opt.Comments[i] = forgejo.CreatePullReviewComment{
+					Path:       c.Path,
+					Body:       c.Body,
+					NewLineNum: int64(c.NewLine),
+					OldLineNum: int64(c.OldLine),
+				}
+			}
+		}
+
+		review, _, err := impl.Client.CreatePullReview(p.Owner, p.Repo, int64(p.Index), opt)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create review: %w", err)
+		}
+
+		wrapper := &types.PullReview{PullReview: review}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{
+					Text: wrapper.ToMarkdown(),
+				},
+			},
+		}, nil, nil
+	}
+}

--- a/tools/pullreq/review_list.go
+++ b/tools/pullreq/review_list.go
@@ -1,0 +1,120 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright © 2025 Ronmi Ren <ronmi.ren@gmail.com>
+
+package pullreq
+
+import (
+	"context"
+	"fmt"
+
+	"codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v2"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/raohwork/forgejo-mcp/tools"
+	"github.com/raohwork/forgejo-mcp/types"
+)
+
+// ListPullRequestReviewsParams defines the parameters for the
+// list_pull_request_reviews tool.
+type ListPullRequestReviewsParams struct {
+	// Owner is the username or organization name that owns the repository.
+	Owner string `json:"owner"`
+	// Repo is the name of the repository.
+	Repo string `json:"repo"`
+	// Index is the pull request number.
+	Index int `json:"index"`
+	// Page is the page number for pagination.
+	Page int `json:"page,omitempty"`
+	// Limit is the number of reviews to return per page.
+	Limit int `json:"limit,omitempty"`
+}
+
+// ListPullRequestReviewsImpl implements the read-only MCP tool for listing all
+// reviews on a pull request. Each review summary includes the inline-comment
+// count so the caller can then drill into specific reviews.
+type ListPullRequestReviewsImpl struct {
+	Client *tools.Client
+}
+
+func (ListPullRequestReviewsImpl) Definition() *mcp.Tool {
+	return &mcp.Tool{
+		Name:        "list_pull_request_reviews",
+		Title:       "List Pull Request Reviews",
+		Description: "List all reviews on a pull request, including reviewer, state (approved, changes requested, commented), overall body, and inline comment counts.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:   true,
+			IdempotentHint: true,
+		},
+		InputSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"owner": {
+					Type:        "string",
+					Description: "Repository owner (username or organization name)",
+				},
+				"repo": {
+					Type:        "string",
+					Description: "Repository name",
+				},
+				"index": {
+					Type:        "integer",
+					Description: "Pull request index number",
+				},
+				"page": {
+					Type:        "integer",
+					Description: "Page number for pagination (optional, defaults to 1)",
+					Minimum:     tools.Float64Ptr(1),
+				},
+				"limit": {
+					Type:        "integer",
+					Description: "Number of reviews per page (optional, defaults to 20, max 50)",
+					Minimum:     tools.Float64Ptr(1),
+					Maximum:     tools.Float64Ptr(50),
+				},
+			},
+			Required: []string{"owner", "repo", "index"},
+		},
+	}
+}
+
+func (impl ListPullRequestReviewsImpl) Handler() mcp.ToolHandlerFor[ListPullRequestReviewsParams, any] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, args ListPullRequestReviewsParams) (*mcp.CallToolResult, any, error) {
+		p := args
+
+		opt := forgejo.ListPullReviewsOptions{}
+		if p.Page > 0 {
+			opt.Page = p.Page
+		}
+		if p.Limit > 0 {
+			opt.PageSize = p.Limit
+		}
+
+		reviews, _, err := impl.Client.ListPullReviews(p.Owner, p.Repo, int64(p.Index), opt)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to list reviews: %w", err)
+		}
+
+		var content string
+		if len(reviews) == 0 {
+			content = "No reviews found for this pull request."
+		} else {
+			list := make(types.PullReviewList, len(reviews))
+			for i, r := range reviews {
+				list[i] = &types.PullReview{PullReview: r}
+			}
+			content = fmt.Sprintf("Found %d reviews\n\n%s", len(reviews), list.ToMarkdown())
+		}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{
+					Text: content,
+				},
+			},
+		}, nil, nil
+	}
+}

--- a/tools/pullreq/review_reply.go
+++ b/tools/pullreq/review_reply.go
@@ -1,0 +1,132 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright © 2025 Ronmi Ren <ronmi.ren@gmail.com>
+
+package pullreq
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/raohwork/forgejo-mcp/tools"
+	"github.com/raohwork/forgejo-mcp/types"
+)
+
+// ReplyToReviewCommentParams defines the parameters for the
+// reply_to_review_comment tool.
+type ReplyToReviewCommentParams struct {
+	// Owner is the username or organization name that owns the repository.
+	Owner string `json:"owner"`
+	// Repo is the name of the repository.
+	Repo string `json:"repo"`
+	// Index is the pull request number.
+	Index int `json:"index"`
+	// ReviewID is the ID of the existing review whose thread the reply is added to.
+	ReviewID int `json:"review_id"`
+	// Path is the file path of the comment being replied to.
+	Path string `json:"path"`
+	// Body is the markdown body of the reply.
+	Body string `json:"body"`
+	// NewLine is the 1-based line number on the new (post-change) side of the diff.
+	NewLine int `json:"new_line,omitempty"`
+	// OldLine is the 1-based line number on the old (pre-change) side of the diff.
+	OldLine int `json:"old_line,omitempty"`
+}
+
+// ReplyToReviewCommentImpl implements the MCP tool for adding a reply to an
+// existing pull request review thread. Forgejo groups inline comments by file
+// path and line number, so posting a new comment to the original review at the
+// same path and line continues the conversation in the UI.
+type ReplyToReviewCommentImpl struct {
+	Client *tools.Client
+}
+
+func (ReplyToReviewCommentImpl) Definition() *mcp.Tool {
+	return &mcp.Tool{
+		Name:        "reply_to_review_comment",
+		Title:       "Reply to Pull Request Review Comment",
+		Description: "Reply to an inline pull request review comment by adding a new comment to the existing review at the same file path and line. Use list_pull_request_review_comments to find the review_id, path, and line of the comment you want to reply to.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:    false,
+			DestructiveHint: tools.BoolPtr(false),
+			IdempotentHint:  false,
+		},
+		InputSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"owner": {
+					Type:        "string",
+					Description: "Repository owner (username or organization name)",
+				},
+				"repo": {
+					Type:        "string",
+					Description: "Repository name",
+				},
+				"index": {
+					Type:        "integer",
+					Description: "Pull request index number",
+				},
+				"review_id": {
+					Type:        "integer",
+					Description: "ID of the review whose thread to reply to (from list_pull_request_reviews or list_pull_request_review_comments)",
+				},
+				"path": {
+					Type:        "string",
+					Description: "File path of the comment being replied to, relative to the repository root",
+				},
+				"body": {
+					Type:        "string",
+					Description: "Reply body (markdown supported)",
+				},
+				"new_line": {
+					Type:        "integer",
+					Description: "1-based line number on the new (post-change) side of the diff. Set this OR old_line to match the original comment.",
+					Minimum:     tools.Float64Ptr(1),
+				},
+				"old_line": {
+					Type:        "integer",
+					Description: "1-based line number on the old (pre-change) side of the diff. Set this OR new_line to match the original comment.",
+					Minimum:     tools.Float64Ptr(1),
+				},
+			},
+			Required: []string{"owner", "repo", "index", "review_id", "path", "body"},
+		},
+	}
+}
+
+func (impl ReplyToReviewCommentImpl) Handler() mcp.ToolHandlerFor[ReplyToReviewCommentParams, any] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, args ReplyToReviewCommentParams) (*mcp.CallToolResult, any, error) {
+		p := args
+
+		if p.NewLine == 0 && p.OldLine == 0 {
+			return nil, nil, fmt.Errorf("either new_line or old_line must be provided to locate the comment thread")
+		}
+
+		opt := tools.MyCreatePullReviewCommentOptions{
+			Body:        p.Body,
+			Path:        p.Path,
+			NewPosition: int64(p.NewLine),
+			OldPosition: int64(p.OldLine),
+		}
+
+		comment, err := impl.Client.MyCreatePullReviewComment(p.Owner, p.Repo, int64(p.Index), int64(p.ReviewID), opt)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to reply to review comment: %w", err)
+		}
+
+		wrapper := &types.PullReviewComment{PullReviewComment: comment}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{
+					Text: wrapper.ToMarkdown(),
+				},
+			},
+		}, nil, nil
+	}
+}

--- a/types/pullrequests.go
+++ b/types/pullrequests.go
@@ -8,6 +8,7 @@ package types
 
 import (
 	"fmt"
+	"strings"
 
 	"codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v2"
 )
@@ -67,4 +68,122 @@ func (prl PullRequestList) ToMarkdown() string {
 		markdown += fmt.Sprintf("%d. %s\n", i+1, pr.ToMarkdown())
 	}
 	return markdown
+}
+
+// PullReview represents a pull request review response with embedded SDK review
+// Used by endpoints:
+// - GET /repos/{owner}/{repo}/pulls/{index}/reviews (list)
+// - POST /repos/{owner}/{repo}/pulls/{index}/reviews (create)
+type PullReview struct {
+	*forgejo.PullReview
+}
+
+// ToMarkdown renders a review with reviewer, state, commit, submission time and body.
+// Also reports how many inline comments belong to the review so a caller can decide
+// whether to drill in via list_pull_request_review_comments.
+func (r *PullReview) ToMarkdown() string {
+	if r.PullReview == nil {
+		return "*Invalid review*"
+	}
+	markdown := fmt.Sprintf("Review#%d", r.ID)
+	if r.State != "" {
+		markdown += fmt.Sprintf(" (%s)", r.State)
+	}
+	if r.Reviewer != nil {
+		markdown += " by **" + r.Reviewer.UserName + "**"
+	}
+	if !r.Submitted.IsZero() {
+		markdown += " at " + r.Submitted.Format("2006-01-02 15:04")
+	}
+	markdown += "\n"
+	if r.CommitID != "" {
+		markdown += "Commit: " + r.CommitID + "\n"
+	}
+	markdown += fmt.Sprintf("Inline comments: %d\n", r.CodeCommentsCount)
+	if r.Stale {
+		markdown += "_Stale (PR changed since this review)_\n"
+	}
+	if r.Dismissed {
+		markdown += "_Dismissed_\n"
+	}
+	if r.Body != "" {
+		markdown += "\n" + r.Body
+	}
+	return markdown
+}
+
+// PullReviewList represents a list of reviews for a pull request.
+type PullReviewList []*PullReview
+
+// ToMarkdown renders reviews as a numbered list.
+func (rl PullReviewList) ToMarkdown() string {
+	if len(rl) == 0 {
+		return "*No reviews found*"
+	}
+	markdown := ""
+	for i, r := range rl {
+		markdown += fmt.Sprintf("%d. %s\n\n", i+1, r.ToMarkdown())
+	}
+	return strings.TrimRight(markdown, "\n")
+}
+
+// PullReviewComment represents an inline review comment on a pull request.
+// Used by endpoints:
+// - GET /repos/{owner}/{repo}/pulls/{index}/reviews/{id}/comments
+type PullReviewComment struct {
+	*forgejo.PullReviewComment
+}
+
+// ToMarkdown renders an inline review comment with file path, line number,
+// author, and the diff hunk that provides context for where the comment was left.
+func (c *PullReviewComment) ToMarkdown() string {
+	if c.PullReviewComment == nil {
+		return "*Invalid review comment*"
+	}
+	markdown := fmt.Sprintf("Comment#%d", c.ID)
+	if c.Reviewer != nil {
+		markdown += " by **" + c.Reviewer.UserName + "**"
+	}
+	if !c.Created.IsZero() {
+		markdown += " at " + c.Created.Format("2006-01-02 15:04")
+	}
+	markdown += "\n"
+	if c.Path != "" {
+		line := c.LineNum
+		marker := "new"
+		if line == 0 && c.OldLineNum != 0 {
+			line = c.OldLineNum
+			marker = "old"
+		}
+		if line > 0 {
+			markdown += fmt.Sprintf("File: `%s` (%s line %d)\n", c.Path, marker, line)
+		} else {
+			markdown += fmt.Sprintf("File: `%s`\n", c.Path)
+		}
+	}
+	if c.Resolver != nil {
+		markdown += "Resolved by: " + c.Resolver.UserName + "\n"
+	}
+	if c.DiffHunk != "" {
+		markdown += "\n```diff\n" + strings.TrimRight(c.DiffHunk, "\n") + "\n```\n"
+	}
+	if c.Body != "" {
+		markdown += "\n" + c.Body
+	}
+	return markdown
+}
+
+// PullReviewCommentList represents a list of inline review comments.
+type PullReviewCommentList []*PullReviewComment
+
+// ToMarkdown renders inline review comments as a numbered list separated by rules.
+func (cl PullReviewCommentList) ToMarkdown() string {
+	if len(cl) == 0 {
+		return "*No inline review comments found*"
+	}
+	parts := make([]string, 0, len(cl))
+	for i, c := range cl {
+		parts = append(parts, fmt.Sprintf("%d. %s", i+1, c.ToMarkdown()))
+	}
+	return strings.Join(parts, "\n\n---\n\n")
 }


### PR DESCRIPTION
This PR implements additional tools:

* list_pull_request_reviews
* list_pull_request_review_comments
* create_pull_request_review
* reply_to_review_comment

I'm working on a set of skills in my personal workspace with claude code and forgejo, and I wanted a way to have claude address the comments I was leaving in PRs.  

I figured I'd share this with the project in case you also find it useful. 


This PR was 100% written by Claude Code.