### PR TITLE
fix: include label ID in markdown output

### DIFF
--- a/types/label_test.go
+++ b/types/label_test.go
@@ -23,7 +23,7 @@ func TestLabel_ToMarkdown(t *testing.T) {
 			label: &Label{
 				Label: testLabel(),
 			},
-			required: []string{"bug", "ff0000", "Something isn't working"},
+			required: []string{"bug", "#1", "ff0000", "Something isn't working"},
 		},
 		{
 			name:     "nil label",

--- a/types/labels.go
+++ b/types/labels.go
@@ -7,6 +7,8 @@
 package types
 
 import (
+	"fmt"
+
 	"codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v2"
 )
 
@@ -22,13 +24,13 @@ type Label struct {
 	*forgejo.Label
 }
 
-// ToMarkdown renders a label as a colored badge with name and description
-// Example: **bug** `#ff0000` - Something isn't working
+// ToMarkdown renders a label as a colored badge with id, name and description
+// Example: **bug** #1 `#ff0000` - Something isn't working
 func (l *Label) ToMarkdown() string {
 	if l.Label == nil {
 		return "*Invalid label*"
 	}
-	markdown := "**" + l.Name + "**"
+	markdown := fmt.Sprintf("**%s** #%d", l.Name, l.ID)
 	if l.Color != "" {
 		markdown += " `#" + l.Color + "`"
 	}
@@ -47,8 +49,8 @@ type LabelList []*Label
 
 // ToMarkdown renders labels as a bullet list of colored badges
 // Example:
-// - **bug** `#ff0000` - Something isn't working
-// - **enhancement** `#a2eeef` - New feature or request
+// - **bug** #1 `#ff0000` - Something isn't working
+// - **enhancement** #2 `#a2eeef` - New feature or request
 func (ll LabelList) ToMarkdown() string {
 	if len(ll) == 0 {
 		return "*No labels found*"


### PR DESCRIPTION
## Summary

Mirrors the milestone-ID fix in 861d234 for labels.

`(*Label).ToMarkdown()` and `LabelList.ToMarkdown()` now include the label's numeric `ID` in `#N` format alongside the name, color, and description.

**Before:**
```
- **bug** `#d73a4a` - Something isn't working
- **enhancement** `#a2eeef` - New feature or request
```

**After:**
```
- **bug** #59 `#d73a4a` - Something isn't working
- **enhancement** #64 `#a2eeef` - New feature or request
```

## Why

`create_issue` requires `labels: []int` (label IDs), but the output of `list_repo_labels` previously didn't include the IDs. That forces MCP clients to hit the Forgejo HTTP API directly to map label names to IDs before they can attach labels to a new issue — defeating the point of having `list_repo_labels` as a tool.

Hit this in real use today: an agent went to file two tickets in a Forgejo repo with labels like `bug`/`enhancement`/`priority/high`, `create_issue` rejected the string array with `cannot unmarshal string into Go struct field CreateIssueParams.labels of type int`, and the workaround was a manual `curl /api/v1/repos/{owner}/{repo}/labels` to look up the IDs. With this change, `list_repo_labels` is self-sufficient.

## Format

Matches the milestone fix exactly: `**Name** #ID` prefix, with the existing color/description suffix untouched. Both single-label and label-list views updated.

## Tests

- Extended `TestLabel_ToMarkdown` to assert the `#1` ID is present in the output (`testLabel()` already sets `ID: 1`).
- `go build ./...` and `go test ./...` pass.