### PR TITLE
feat: add list_user_repositories tool, drop unsupported repo-list params

### DIFF
--- a/cmd/lib.go
+++ b/cmd/lib.go
@@ -85,6 +85,7 @@ func registerCommands(s *mcp.Server, cl *tools.Client) {
 	// Repository tools
 	tools.Register(s, &repo.SearchRepositoriesImpl{Client: cl})
 	tools.Register(s, &repo.ListMyRepositoriesImpl{Client: cl})
+	tools.Register(s, &repo.ListUserRepositoriesImpl{Client: cl})
 	tools.Register(s, &repo.ListOrgRepositoriesImpl{Client: cl})
 	tools.Register(s, &repo.GetRepositoryImpl{Client: cl})
 

--- a/tools/repo/doc.go
+++ b/tools/repo/doc.go
@@ -1,5 +1,6 @@
 // Package repo provides MCP tools for interacting with Forgejo repositories.
 //
 // It includes tools for searching repositories, listing repositories owned by the
-// authenticated user or an organization, and getting detailed information about a specific repository.
+// authenticated user, a specific user, or an organization, and getting detailed
+// information about a specific repository.
 package repo

--- a/tools/repo/list.go
+++ b/tools/repo/list.go
@@ -159,16 +159,9 @@ func (impl SearchRepositoriesImpl) Handler() mcp.ToolHandlerFor[SearchRepositori
 }
 
 // ListMyRepositoriesParams defines the parameters for the list_my_repositories tool.
-// It allows filtering and sorting of the authenticated user's repositories.
+// Only pagination is supported: the SDK's ListReposOptions (GET /user/repos) does not
+// accept affiliation, visibility, or sorting parameters.
 type ListMyRepositoriesParams struct {
-	// Affiliation filters repositories by the user's role.
-	Affiliation string `json:"affiliation,omitempty"`
-	// Visibility filters repositories by their public or private status.
-	Visibility string `json:"visibility,omitempty"`
-	// Sort specifies the sort order for the results.
-	Sort string `json:"sort,omitempty"`
-	// Direction specifies the sort direction (asc or desc).
-	Direction string `json:"direction,omitempty"`
 	// Page is the page number for pagination.
 	Page int `json:"page,omitempty"`
 	// Limit is the number of repositories to return per page.
@@ -182,13 +175,13 @@ type ListMyRepositoriesImpl struct {
 	Client *tools.Client
 }
 
-// Definition describes the `list_my_repositories` tool. It supports optional
-// parameters for filtering and sorting, and is marked as a safe, read-only operation.
+// Definition describes the `list_my_repositories` tool. It supports pagination only
+// and is marked as a safe, read-only operation.
 func (ListMyRepositoriesImpl) Definition() *mcp.Tool {
 	return &mcp.Tool{
 		Name:        "list_my_repositories",
 		Title:       "List My Repositories",
-		Description: "List repositories owned by the authenticated user. Returns repository information including name, description, and metadata.",
+		Description: "List repositories the authenticated user has access to. Returns repository information including name, description, and metadata.",
 		Annotations: &mcp.ToolAnnotations{
 			ReadOnlyHint:   true,
 			IdempotentHint: true,
@@ -196,26 +189,6 @@ func (ListMyRepositoriesImpl) Definition() *mcp.Tool {
 		InputSchema: &jsonschema.Schema{
 			Type: "object",
 			Properties: map[string]*jsonschema.Schema{
-				"affiliation": {
-					Type:        "string",
-					Description: "Repository affiliation filter: 'owner', 'collaborator', 'organization_member', or 'all' (optional, defaults to 'all')",
-					Enum:        []any{"owner", "collaborator", "organization_member", "all"},
-				},
-				"visibility": {
-					Type:        "string",
-					Description: "Repository visibility filter: 'all', 'public', 'private' (optional, defaults to 'all')",
-					Enum:        []any{"all", "public", "private"},
-				},
-				"sort": {
-					Type:        "string",
-					Description: "Sort order: 'created', 'updated', 'pushed', 'full_name' (optional, defaults to 'full_name')",
-					Enum:        []any{"created", "updated", "pushed", "full_name"},
-				},
-				"direction": {
-					Type:        "string",
-					Description: "Sort direction: 'asc' or 'desc' (optional, defaults to 'asc')",
-					Enum:        []any{"asc", "desc"},
-				},
 				"page": {
 					Type:        "integer",
 					Description: "Page number for pagination (optional, defaults to 1)",
@@ -281,17 +254,110 @@ func (impl ListMyRepositoriesImpl) Handler() mcp.ToolHandlerFor[ListMyRepositori
 	}
 }
 
+// ListUserRepositoriesParams defines the parameters for the list_user_repositories tool.
+// It lists the repositories owned by a specific user.
+type ListUserRepositoriesParams struct {
+	// User is the username whose repositories will be listed.
+	User string `json:"user"`
+	// Page is the page number for pagination.
+	Page int `json:"page,omitempty"`
+	// Limit is the number of repositories to return per page.
+	Limit int `json:"limit,omitempty"`
+}
+
+// ListUserRepositoriesImpl implements the read-only MCP tool for listing a specific
+// user's repositories. This is a safe, idempotent operation that uses the Forgejo SDK.
+type ListUserRepositoriesImpl struct {
+	Client *tools.Client
+}
+
+// Definition describes the `list_user_repositories` tool. It requires a `user` name
+// and supports pagination only. It is marked as a safe, read-only operation.
+func (ListUserRepositoriesImpl) Definition() *mcp.Tool {
+	return &mcp.Tool{
+		Name:        "list_user_repositories",
+		Title:       "List User Repositories",
+		Description: "List repositories owned by a specific user. Returns repository information including name, description, and metadata.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:   true,
+			IdempotentHint: true,
+		},
+		InputSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"user": {
+					Type:        "string",
+					Description: "Username whose repositories will be listed",
+				},
+				"page": {
+					Type:        "integer",
+					Description: "Page number for pagination (optional, defaults to 1)",
+					Minimum:     tools.Float64Ptr(1),
+				},
+				"limit": {
+					Type:        "integer",
+					Description: "Number of repositories per page (optional, defaults to 20, max 50)",
+					Minimum:     tools.Float64Ptr(1),
+					Maximum:     tools.Float64Ptr(50),
+				},
+			},
+			Required: []string{"user"},
+		},
+	}
+}
+
+// Handler implements the logic for listing a user's repositories. It calls the
+// Forgejo SDK's `ListUserRepos` function and formats the results into a markdown list.
+func (impl ListUserRepositoriesImpl) Handler() mcp.ToolHandlerFor[ListUserRepositoriesParams, any] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, args ListUserRepositoriesParams) (*mcp.CallToolResult, any, error) {
+		p := args
+
+		// Build options for SDK call
+		opt := forgejo.ListReposOptions{}
+		if p.Page > 0 {
+			opt.Page = p.Page
+		}
+		if p.Limit > 0 {
+			opt.PageSize = p.Limit
+		}
+
+		// Call SDK
+		repos, _, err := impl.Client.ListUserRepos(p.User, opt)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to list user repositories: %w", err)
+		}
+
+		// Convert to our types and format
+		var content string
+		if len(repos) == 0 {
+			content = fmt.Sprintf("No repositories found for user '%s'.", p.User)
+		} else {
+			// Convert repos to our type
+			repoList := make(types.RepositoryList, len(repos))
+			for i, repo := range repos {
+				repoList[i] = &types.Repository{Repository: repo}
+			}
+
+			content = fmt.Sprintf("Found %d repositories for user '%s'\n\n%s",
+				len(repos), p.User, repoList.ToMarkdown())
+		}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{
+					Text: content,
+				},
+			},
+		}, nil, nil
+	}
+}
+
 // ListOrgRepositoriesParams defines the parameters for the list_org_repositories tool.
-// It specifies the organization and allows for filtering and sorting.
+// Besides the organization name, only pagination is supported: the SDK's
+// ListOrgReposOptions (GET /orgs/{org}/repos) does not accept type or sorting parameters.
 type ListOrgRepositoriesParams struct {
 	// Org is the name of the organization.
 	Org string `json:"org"`
-	// Type filters repositories by their type (e.g., forks, sources).
-	Type string `json:"type,omitempty"`
-	// Sort specifies the sort order for the results.
-	Sort string `json:"sort,omitempty"`
-	// Direction specifies the sort direction (asc or desc).
-	Direction string `json:"direction,omitempty"`
 	// Page is the page number for pagination.
 	Page int `json:"page,omitempty"`
 	// Limit is the number of repositories to return per page.
@@ -306,8 +372,7 @@ type ListOrgRepositoriesImpl struct {
 }
 
 // Definition describes the `list_org_repositories` tool. It requires an `org` name
-// and supports optional parameters for filtering and sorting. It is marked as a
-// safe, read-only operation.
+// and supports pagination only. It is marked as a safe, read-only operation.
 func (ListOrgRepositoriesImpl) Definition() *mcp.Tool {
 	return &mcp.Tool{
 		Name:        "list_org_repositories",
@@ -323,21 +388,6 @@ func (ListOrgRepositoriesImpl) Definition() *mcp.Tool {
 				"org": {
 					Type:        "string",
 					Description: "Organization name",
-				},
-				"type": {
-					Type:        "string",
-					Description: "Repository type filter: 'all', 'public', 'private', 'forks', 'sources', 'member' (optional, defaults to 'all')",
-					Enum:        []any{"all", "public", "private", "forks", "sources", "member"},
-				},
-				"sort": {
-					Type:        "string",
-					Description: "Sort order: 'created', 'updated', 'pushed', 'full_name' (optional, defaults to 'created')",
-					Enum:        []any{"created", "updated", "pushed", "full_name"},
-				},
-				"direction": {
-					Type:        "string",
-					Description: "Sort direction: 'asc' or 'desc' (optional, defaults to 'desc')",
-					Enum:        []any{"asc", "desc"},
 				},
 				"page": {
 					Type:        "integer",


### PR DESCRIPTION
Fixes #12.

This addresses the two repository-listing issues reported in #12.

## 1. Add `list_user_repositories`

There was no tool to list the repositories of a *specific* user — `list_org_repositories` only works for orgs (returns `GetOrgByName` when given a username) and `list_my_repositories` is limited to the authenticated user.

The SDK already exposes `(*Client).ListUserRepos(user, opt)` → `GET /users/{user}/repos`, so the new tool mirrors the existing `list_org_repositories` implementation: a required `user` param plus `page`/`limit`. Registered in `cmd/lib.go`.

## 2. Drop unsupported (phantom) params from the existing list tools

`list_my_repositories` advertised `affiliation`, `visibility`, `sort`, `direction`, and `list_org_repositories` advertised `type`, `sort`, `direction` — but the handlers only ever set `Page`/`Limit` on the SDK options. Structurally, `ListReposOptions` and `ListOrgReposOptions` embed only `ListOptions` (page + pagesize), so those params could never be honored. They were silently ignored, which makes a filtered/sorted call look like it worked when it didn't.

These params are removed from the schemas and param structs so the tools no longer claim capabilities the SDK can't deliver. Pagination behavior is unchanged. (If server-side filtering/sorting is wanted later, it'd need the SDK option structs to support those query params first.)

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` all pass
- `gofmt` clean
